### PR TITLE
Superseded: split ECR composite actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
 # gh-actions
+
+Reusable GitHub Actions and composite actions for quiltdata repos.
+
+## Actions
+
+### [build-and-push-ecr](./build-and-push-ecr)
+
+Build a Docker image and push to a configurable subset of ECR targets:
+`prod` (account 730278974607, us-east-1), `mp` (Marketplace, cross-account
+709825985650), `govcloud` (account 313325871032, us-gov-east-1).
+
+`push-targets: '[]'` builds only — useful for dev iteration via
+`workflow_dispatch` without polluting any ECR.
+
+```yaml
+- uses: actions/checkout@v6
+- uses: quiltdata/gh-actions/build-and-push-ecr@main
+  with:
+    image-name: quiltdata/catalog
+    push-targets: ${{ inputs.push-targets || '["prod","govcloud","mp"]' }}
+    mp-image-name: quilt-data/quilt-payg-catalog
+    role-name: Quilt
+```
+
+### [fargate-deploy-ecr](./fargate-deploy-ecr)
+
+Same build + push flow, plus `aws ecs update-service --force-new-deployment`
+per target for ECS Fargate services. Targets: `prod`, `govcloud` (no MP —
+Marketplace is a distribution registry, not a deploy target).
+
+```yaml
+- uses: actions/checkout@v6
+- uses: quiltdata/gh-actions/fargate-deploy-ecr@main
+  with:
+    image-name: quiltdata/services/foo
+    cluster-name: my-cluster
+    service-name: my-service
+    push-targets: ${{ inputs.push-targets || '["prod","govcloud"]' }}
+```
+
+### [lambda-deploy-ecr](./lambda-deploy-ecr)
+
+Legacy lambda image build + push. Pushes to all enabled regions per account
+(needed because Lambda functions are region-scoped). Kept for back-compat;
+new lambda workflows can use `build-and-push-ecr` if multi-region push is
+not required.
+
+### [lambda-upload-s3](./lambda-upload-s3)
+
+Build a lambda zip via the lambda builder image and upload to S3.
+
+## Conventions
+
+- All ECR-pushing actions assume the consumer repo has an IAM role at
+  `arn:aws:iam::<account>:role/github/GitHub-<role-name>` (and the GovCloud
+  equivalent), where `<role-name>` defaults to the repo name and can be
+  overridden via the `role-name` input.
+- The `push-targets` JSON-array pattern — default `["prod","govcloud"]` for
+  push events, `["prod"]` or `[]` for `workflow_dispatch` — is the org
+  convention for letting `workflow_dispatch` produce dev images without
+  pushing to release-channel registries (Marketplace, GovCloud).
+- Callers are responsible for `actions/checkout` before calling
+  `build-and-push-ecr` or `fargate-deploy-ecr` (so a pre-build step like
+  `npm run build` can populate the workspace first). The legacy
+  `lambda-deploy-ecr` does its own checkout.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,56 @@ Reusable GitHub Actions and composite actions for quiltdata repos.
 
 ## Actions
 
+### [deploy-ecr](./deploy-ecr)
+
+Unified ECR image action. Builds a Docker image from the caller's checked-out
+workspace, pushes it to a configurable subset of ECR targets, and optionally
+forces ECS Fargate deployments for deployable targets.
+
+Targets:
+
+- `prod` — account 730278974607, us-east-1
+- `mp` — Marketplace account 709825985650, us-east-1, push-only
+- `govcloud` — account 313325871032, us-gov-east-1
+
+`push_targets: '[]'` builds only. Empty `image_tag` resolves to
+`git rev-parse HEAD`, which keeps image tags correct when a dispatch workflow
+checks out a different branch than the dispatching ref.
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    ref: ${{ inputs.ref || github.ref }}
+- uses: quiltdata/gh-actions/deploy-ecr@main
+  with:
+    image_name: quiltdata/catalog
+    push_targets: ${{ inputs.push_targets || '["prod","mp","govcloud"]' }}
+    mp_image_name: quilt-data/quilt-payg-catalog
+    role_name: Quilt
+```
+
+For ECS services, pass `cluster_name` and `service_name`; deployments run for
+pushed `prod` and `govcloud` targets only.
+
+```yaml
+- uses: quiltdata/gh-actions/deploy-ecr@main
+  with:
+    image_name: quiltdata/services/foo
+    cluster_name: my-cluster
+    service_name: my-service
+    push_targets: ${{ inputs.push_targets || '["prod","govcloud"]' }}
+```
+
+For Lambda-style image fanout, set `multi_region: 'true'` to push to every
+enabled region in each selected target account.
+
 ### [build-and-push-ecr](./build-and-push-ecr)
 
 Build a Docker image and push to a configurable subset of ECR targets:
 `prod` (account 730278974607, us-east-1), `mp` (Marketplace, cross-account
 709825985650), `govcloud` (account 313325871032, us-gov-east-1).
+
+Legacy split action. Prefer `deploy-ecr` for new workflows.
 
 `push-targets: '[]'` builds only — useful for dev iteration via
 `workflow_dispatch` without polluting any ECR.
@@ -29,6 +74,8 @@ Same build + push flow, plus `aws ecs update-service --force-new-deployment`
 per target for ECS Fargate services. Targets: `prod`, `govcloud` (no MP —
 Marketplace is a distribution registry, not a deploy target).
 
+Legacy split action. Prefer `deploy-ecr` for new workflows.
+
 ```yaml
 - uses: actions/checkout@v6
 - uses: quiltdata/gh-actions/fargate-deploy-ecr@main
@@ -43,8 +90,7 @@ Marketplace is a distribution registry, not a deploy target).
 
 Legacy lambda image build + push. Pushes to all enabled regions per account
 (needed because Lambda functions are region-scoped). Kept for back-compat;
-new lambda workflows can use `build-and-push-ecr` if multi-region push is
-not required.
+new lambda workflows can use `deploy-ecr` with `multi_region: 'true'`.
 
 ### [lambda-upload-s3](./lambda-upload-s3)
 
@@ -56,11 +102,10 @@ Build a lambda zip via the lambda builder image and upload to S3.
   `arn:aws:iam::<account>:role/github/GitHub-<role-name>` (and the GovCloud
   equivalent), where `<role-name>` defaults to the repo name and can be
   overridden via the `role-name` input.
-- The `push-targets` JSON-array pattern — default `["prod","govcloud"]` for
+- The `push_targets` JSON-array pattern — default `["prod","govcloud"]` for
   push events, `["prod"]` or `[]` for `workflow_dispatch` — is the org
   convention for letting `workflow_dispatch` produce dev images without
   pushing to release-channel registries (Marketplace, GovCloud).
 - Callers are responsible for `actions/checkout` before calling
-  `build-and-push-ecr` or `fargate-deploy-ecr` (so a pre-build step like
-  `npm run build` can populate the workspace first). The legacy
-  `lambda-deploy-ecr` does its own checkout.
+  `deploy-ecr` (so a pre-build step like `npm run build` can populate the
+  workspace first). The legacy `lambda-deploy-ecr` does its own checkout.

--- a/build-and-push-ecr/action.yaml
+++ b/build-and-push-ecr/action.yaml
@@ -1,0 +1,125 @@
+name: 'Build and push to ECR'
+description: 'Build a Docker image and push to selected ECR targets (Prod / Marketplace / GovCloud). Caller is responsible for actions/checkout.'
+
+inputs:
+  dockerfile-path:
+    description: 'Path to the Dockerfile (relative to the workflow workspace)'
+    default: 'Dockerfile'
+  docker-context-path:
+    description: 'Docker build context'
+    default: '.'
+  image-name:
+    description: 'ECR image repository path (e.g. quiltdata/services/foo, quiltdata/catalog)'
+    required: true
+  image-tag:
+    description: 'Image tag'
+    default: ${{ github.sha }}
+  push-targets:
+    description: 'JSON array, subset of ["prod","mp","govcloud"]. [] = build only.'
+    default: '["prod","govcloud"]'
+  role-name:
+    description: 'IAM role suffix; defaults to the repo name. Full role: GitHub-<role-name>.'
+    default: ''
+  mp-image-name:
+    description: 'Override image-name for the mp target (e.g. quilt-data/quilt-payg-catalog).'
+    default: ''
+
+outputs:
+  image-uri-prod:
+    description: 'Full image URI in Prod ECR (empty if prod not pushed)'
+    value: ${{ steps.push-prod.outputs.uri }}
+  image-uri-mp:
+    description: 'Full image URI in Marketplace ECR (empty if mp not pushed)'
+    value: ${{ steps.push-mp.outputs.uri }}
+  image-uri-govcloud:
+    description: 'Full image URI in GovCloud ECR (empty if govcloud not pushed)'
+    value: ${{ steps.push-govcloud.outputs.uri }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve role name
+      id: cfg
+      shell: bash
+      run: |
+        NAME='${{ inputs.role-name }}'
+        [ -z "$NAME" ] && NAME=${GITHUB_REPOSITORY#*/}
+        echo "role-name=$NAME" >> "$GITHUB_OUTPUT"
+
+    - name: Build Docker image
+      shell: bash
+      run: |
+        docker buildx build --load \
+          -t "${{ inputs.image-name }}:${{ inputs.image-tag }}" \
+          -f "${{ inputs.dockerfile-path }}" \
+          "${{ inputs.docker-context-path }}"
+
+    # ----- Prod / Marketplace path (both authenticate via the Prod IAM role) -----
+    - if: contains(fromJSON(inputs.push-targets), 'prod') || contains(fromJSON(inputs.push-targets), 'mp')
+      name: Configure AWS credentials (Prod)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-${{ steps.cfg.outputs.role-name }}
+        aws-region: us-east-1
+
+    - if: contains(fromJSON(inputs.push-targets), 'prod')
+      name: Login to Prod ECR
+      id: ecr-prod
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - if: contains(fromJSON(inputs.push-targets), 'prod')
+      name: Push to Prod ECR
+      id: push-prod
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.ecr-prod.outputs.registry }}
+      run: |
+        URI="$REGISTRY/${{ inputs.image-name }}:${{ inputs.image-tag }}"
+        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        docker push "$URI"
+        echo "uri=$URI" >> "$GITHUB_OUTPUT"
+
+    - if: contains(fromJSON(inputs.push-targets), 'mp')
+      name: Login to Marketplace ECR
+      id: ecr-mp
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registries: '709825985650'
+
+    - if: contains(fromJSON(inputs.push-targets), 'mp')
+      name: Push to Marketplace ECR
+      id: push-mp
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.ecr-mp.outputs.registry }}
+        MP_NAME: ${{ inputs.mp-image-name || inputs.image-name }}
+      run: |
+        URI="$REGISTRY/$MP_NAME:${{ inputs.image-tag }}"
+        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        docker push "$URI"
+        echo "uri=$URI" >> "$GITHUB_OUTPUT"
+
+    # ----- GovCloud path -----
+    - if: contains(fromJSON(inputs.push-targets), 'govcloud')
+      name: Configure AWS credentials (GovCloud)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-${{ steps.cfg.outputs.role-name }}
+        aws-region: us-gov-east-1
+
+    - if: contains(fromJSON(inputs.push-targets), 'govcloud')
+      name: Login to GovCloud ECR
+      id: ecr-govcloud
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - if: contains(fromJSON(inputs.push-targets), 'govcloud')
+      name: Push to GovCloud ECR
+      id: push-govcloud
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.ecr-govcloud.outputs.registry }}
+      run: |
+        URI="$REGISTRY/${{ inputs.image-name }}:${{ inputs.image-tag }}"
+        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        docker push "$URI"
+        echo "uri=$URI" >> "$GITHUB_OUTPUT"

--- a/build-and-push-ecr/action.yaml
+++ b/build-and-push-ecr/action.yaml
@@ -38,21 +38,31 @@ outputs:
 runs:
   using: composite
   steps:
+    # All shell steps reference inputs via env vars rather than ${{ }} template
+    # interpolation, per GitHub's security hardening guide:
+    # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
     - name: Resolve role name
       id: cfg
       shell: bash
+      env:
+        ROLE_NAME_INPUT: ${{ inputs.role-name }}
       run: |
-        NAME='${{ inputs.role-name }}'
+        NAME="$ROLE_NAME_INPUT"
         [ -z "$NAME" ] && NAME=${GITHUB_REPOSITORY#*/}
         echo "role-name=$NAME" >> "$GITHUB_OUTPUT"
 
     - name: Build Docker image
       shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
+        DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
+        DOCKER_CONTEXT_PATH: ${{ inputs.docker-context-path }}
       run: |
         docker buildx build --load \
-          -t "${{ inputs.image-name }}:${{ inputs.image-tag }}" \
-          -f "${{ inputs.dockerfile-path }}" \
-          "${{ inputs.docker-context-path }}"
+          -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+          -f "$DOCKERFILE_PATH" \
+          "$DOCKER_CONTEXT_PATH"
 
     # ----- Prod / Marketplace path (both authenticate via the Prod IAM role) -----
     - if: contains(fromJSON(inputs.push-targets), 'prod') || contains(fromJSON(inputs.push-targets), 'mp')
@@ -73,9 +83,11 @@ runs:
       shell: bash
       env:
         REGISTRY: ${{ steps.ecr-prod.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
       run: |
-        URI="$REGISTRY/${{ inputs.image-name }}:${{ inputs.image-tag }}"
-        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        URI="$REGISTRY/${IMAGE_NAME}:${IMAGE_TAG}"
+        docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "$URI"
         docker push "$URI"
         echo "uri=$URI" >> "$GITHUB_OUTPUT"
 
@@ -92,10 +104,12 @@ runs:
       shell: bash
       env:
         REGISTRY: ${{ steps.ecr-mp.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
         MP_NAME: ${{ inputs.mp-image-name || inputs.image-name }}
       run: |
-        URI="$REGISTRY/$MP_NAME:${{ inputs.image-tag }}"
-        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        URI="$REGISTRY/${MP_NAME}:${IMAGE_TAG}"
+        docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "$URI"
         docker push "$URI"
         echo "uri=$URI" >> "$GITHUB_OUTPUT"
 
@@ -118,8 +132,10 @@ runs:
       shell: bash
       env:
         REGISTRY: ${{ steps.ecr-govcloud.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
       run: |
-        URI="$REGISTRY/${{ inputs.image-name }}:${{ inputs.image-tag }}"
-        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        URI="$REGISTRY/${IMAGE_NAME}:${IMAGE_TAG}"
+        docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "$URI"
         docker push "$URI"
         echo "uri=$URI" >> "$GITHUB_OUTPUT"

--- a/deploy-ecr/action.yaml
+++ b/deploy-ecr/action.yaml
@@ -1,0 +1,205 @@
+---
+# yamllint disable rule:line-length
+name: 'Deploy ECR image'
+description: 'Build a Docker image, push to selected ECR targets, and optionally force ECS service deployments.'
+
+inputs:
+  dockerfile_path:
+    description: 'Path to the Dockerfile, relative to the workflow workspace.'
+    default: 'Dockerfile'
+  docker_context_path:
+    description: 'Docker build context.'
+    default: '.'
+  image_name:
+    description: 'ECR repository path, e.g. quiltdata/catalog or quiltdata/services/foo.'
+    required: true
+  image_tag:
+    description: 'Image tag. Empty resolves to git rev-parse HEAD after caller checkout.'
+    default: ''
+  mp_image_name:
+    description: 'Override image_name for the mp target, e.g. quilt-data/quilt-payg-catalog.'
+    default: ''
+  push_targets:
+    description: 'JSON array, subset of ["prod","mp","govcloud"]. [] = build only.'
+    default: '["prod","govcloud"]'
+  multi_region:
+    description: 'If true, push to every enabled region in each target account.'
+    default: 'false'
+  role_name:
+    description: 'IAM role suffix; defaults to the caller repo name. Full role: GitHub-<role_name>.'
+    default: ''
+  cluster_name:
+    description: 'ECS cluster. If set with service_name, deploys to pushed prod/govcloud targets. mp is push-only.'
+    default: ''
+  service_name:
+    description: 'ECS service. If set with cluster_name, deploys to pushed prod/govcloud targets. mp is push-only.'
+    default: ''
+
+outputs:
+  image_tag:
+    description: 'The tag actually used.'
+    value: ${{ steps.resolve_tag.outputs.value }}
+  image_uri_prod:
+    description: 'Full image URI in Prod ECR, empty if prod was not pushed.'
+    value: ${{ steps.push_prod.outputs.uri }}
+  image_uri_mp:
+    description: 'Full image URI in Marketplace ECR, empty if mp was not pushed.'
+    value: ${{ steps.push_mp.outputs.uri }}
+  image_uri_govcloud:
+    description: 'Full image URI in GovCloud ECR, empty if govcloud was not pushed.'
+    value: ${{ steps.push_govcloud.outputs.uri }}
+
+runs:
+  using: composite
+  steps:
+    # All shell steps reference inputs via env vars rather than direct
+    # expression interpolation, per GitHub's security hardening guide.
+    - name: Warn if ECS inputs have no deployable target
+      if: inputs.cluster_name != '' || inputs.service_name != ''
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster_name }}
+        SERVICE_NAME: ${{ inputs.service_name }}
+        PUSH_TARGETS: ${{ inputs.push_targets }}
+      run: |
+        if [ -z "$CLUSTER_NAME" ] || [ -z "$SERVICE_NAME" ]; then
+          echo "::warning::Both cluster_name and service_name are required for ECS deployment; ECS update will be skipped."
+        elif ! echo "$PUSH_TARGETS" | grep -qE '"(prod|govcloud)"'; then
+          echo "::warning::cluster_name/service_name were set, but push_targets contains no deployable target (prod or govcloud); ECS update will be skipped."
+        fi
+
+    - name: Resolve image tag
+      id: resolve_tag
+      shell: bash
+      env:
+        TAG_INPUT: ${{ inputs.image_tag }}
+      run: |
+        TAG="$TAG_INPUT"
+        [ -z "$TAG" ] && TAG="$(git rev-parse HEAD)"
+        echo "value=$TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve role name
+      id: cfg
+      shell: bash
+      env:
+        ROLE_NAME_INPUT: ${{ inputs.role_name }}
+      run: |
+        NAME="$ROLE_NAME_INPUT"
+        [ -z "$NAME" ] && NAME="${GITHUB_REPOSITORY#*/}"
+        echo "role_name=$NAME" >> "$GITHUB_OUTPUT"
+
+    - name: Build Docker image
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+        DOCKER_CONTEXT_PATH: ${{ inputs.docker_context_path }}
+      run: |
+        docker buildx build --load \
+          -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+          -f "$DOCKERFILE_PATH" \
+          "$DOCKER_CONTEXT_PATH"
+
+    # ----- Prod / Marketplace path (both authenticate via the Prod IAM role) -----
+    - if: contains(fromJSON(inputs.push_targets), 'prod') || contains(fromJSON(inputs.push_targets), 'mp')
+      name: Configure AWS credentials (Prod)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-${{ steps.cfg.outputs.role_name }}
+        aws-region: us-east-1
+
+    - if: contains(fromJSON(inputs.push_targets), 'prod')
+      name: Login to Prod ECR
+      id: ecr_prod
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - if: contains(fromJSON(inputs.push_targets), 'prod')
+      name: Push to Prod ECR
+      id: push_prod
+      shell: bash
+      env:
+        TARGET: prod
+        REGISTRY: ${{ steps.ecr_prod.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image_name }}
+        IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        MULTI_REGION: ${{ inputs.multi_region }}
+      run: ${{ github.action_path }}/push_target.sh
+
+    - if: contains(fromJSON(inputs.push_targets), 'prod') && inputs.cluster_name != '' && inputs.service_name != ''
+      name: Update Fargate service (Prod)
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster_name }}
+        SERVICE_NAME: ${{ inputs.service_name }}
+      run: |
+        aws ecs update-service \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME" \
+          --force-new-deployment \
+          --no-cli-pager
+        aws ecs wait services-stable \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME"
+
+    # ----- Marketplace is a distribution registry, not a deploy target. -----
+    - if: contains(fromJSON(inputs.push_targets), 'mp')
+      name: Login to Marketplace ECR
+      id: ecr_mp
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registries: '709825985650'
+
+    - if: contains(fromJSON(inputs.push_targets), 'mp')
+      name: Push to Marketplace ECR
+      id: push_mp
+      shell: bash
+      env:
+        TARGET: mp
+        REGISTRY: ${{ steps.ecr_mp.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.mp_image_name || inputs.image_name }}
+        SOURCE_IMAGE: ${{ inputs.image_name }}:${{ steps.resolve_tag.outputs.value }}
+        IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        MULTI_REGION: 'false'
+      run: ${{ github.action_path }}/push_target.sh
+
+    # ----- GovCloud path -----
+    - if: contains(fromJSON(inputs.push_targets), 'govcloud')
+      name: Configure AWS credentials (GovCloud)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-${{ steps.cfg.outputs.role_name }}
+        aws-region: us-gov-east-1
+
+    - if: contains(fromJSON(inputs.push_targets), 'govcloud')
+      name: Login to GovCloud ECR
+      id: ecr_govcloud
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - if: contains(fromJSON(inputs.push_targets), 'govcloud')
+      name: Push to GovCloud ECR
+      id: push_govcloud
+      shell: bash
+      env:
+        TARGET: govcloud
+        REGISTRY: ${{ steps.ecr_govcloud.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image_name }}
+        IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        MULTI_REGION: ${{ inputs.multi_region }}
+      run: ${{ github.action_path }}/push_target.sh
+
+    - if: contains(fromJSON(inputs.push_targets), 'govcloud') && inputs.cluster_name != '' && inputs.service_name != ''
+      name: Update Fargate service (GovCloud)
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster_name }}
+        SERVICE_NAME: ${{ inputs.service_name }}
+      run: |
+        aws ecs update-service \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME" \
+          --force-new-deployment \
+          --no-cli-pager
+        aws ecs wait services-stable \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME"

--- a/deploy-ecr/push_target.sh
+++ b/deploy-ecr/push_target.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${REGISTRY:?REGISTRY is required}"
+: "${IMAGE_NAME:?IMAGE_NAME is required}"
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+
+ACCOUNT_ID="${REGISTRY%%.*}"
+SOURCE="${SOURCE_IMAGE:-$IMAGE_NAME:$IMAGE_TAG}"
+MULTI_REGION="${MULTI_REGION:-false}"
+
+push_to_region() {
+  local region="$1"
+  local docker_url="$ACCOUNT_ID.dkr.ecr.$region.amazonaws.com"
+  local remote="$docker_url/$IMAGE_NAME:$IMAGE_TAG"
+
+  echo "Logging in to $docker_url..."
+  aws ecr get-login-password --region "$region" |
+    docker login -u AWS --password-stdin "$docker_url"
+
+  echo "Pushing $SOURCE to $remote..."
+  docker tag "$SOURCE" "$remote"
+  docker push "$remote"
+  echo "uri=$remote" >> "$GITHUB_OUTPUT"
+}
+
+if [ "$MULTI_REGION" = "true" ]; then
+  regions="$(aws ec2 describe-regions --query 'Regions[].RegionName' --output text)"
+  for region in $regions; do
+    push_to_region "$region"
+  done
+else
+  region="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+  if [ -z "$region" ]; then
+    echo "::error::AWS_REGION or AWS_DEFAULT_REGION is required for single-region push"
+    exit 1
+  fi
+  push_to_region "$region"
+fi

--- a/fargate-deploy-ecr/action.yaml
+++ b/fargate-deploy-ecr/action.yaml
@@ -1,0 +1,127 @@
+name: 'Deploy to Fargate'
+description: 'Build a Docker image, push to selected ECR targets (Prod / GovCloud), and force a new ECS service deployment in each target. Caller is responsible for actions/checkout.'
+
+inputs:
+  dockerfile-path:
+    description: 'Path to the Dockerfile (relative to the workflow workspace)'
+    default: 'Dockerfile'
+  docker-context-path:
+    description: 'Docker build context'
+    default: '.'
+  image-name:
+    description: 'ECR image repository path (e.g. quiltdata/services/foo)'
+    required: true
+  image-tag:
+    description: 'Image tag'
+    default: ${{ github.sha }}
+  push-targets:
+    description: 'JSON array, subset of ["prod","govcloud"]. [] = build only, no push, no deploy.'
+    default: '["prod","govcloud"]'
+  role-name:
+    description: 'IAM role suffix; defaults to the repo name. Full role: GitHub-<role-name>.'
+    default: ''
+  service-name:
+    description: 'ECS service name (required when push-targets is non-empty)'
+    required: true
+  cluster-name:
+    description: 'ECS cluster name (required when push-targets is non-empty)'
+    required: true
+
+outputs:
+  image-uri-prod:
+    description: 'Full image URI in Prod ECR (empty if prod not pushed)'
+    value: ${{ steps.push-prod.outputs.uri }}
+  image-uri-govcloud:
+    description: 'Full image URI in GovCloud ECR (empty if govcloud not pushed)'
+    value: ${{ steps.push-govcloud.outputs.uri }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve role name
+      id: cfg
+      shell: bash
+      run: |
+        NAME='${{ inputs.role-name }}'
+        [ -z "$NAME" ] && NAME=${GITHUB_REPOSITORY#*/}
+        echo "role-name=$NAME" >> "$GITHUB_OUTPUT"
+
+    - name: Build Docker image
+      shell: bash
+      run: |
+        docker buildx build --load \
+          -t "${{ inputs.image-name }}:${{ inputs.image-tag }}" \
+          -f "${{ inputs.dockerfile-path }}" \
+          "${{ inputs.docker-context-path }}"
+
+    # ----- Prod -----
+    - if: contains(fromJSON(inputs.push-targets), 'prod')
+      name: Configure AWS credentials (Prod)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-${{ steps.cfg.outputs.role-name }}
+        aws-region: us-east-1
+
+    - if: contains(fromJSON(inputs.push-targets), 'prod')
+      name: Login to Prod ECR
+      id: ecr-prod
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - if: contains(fromJSON(inputs.push-targets), 'prod')
+      name: Push to Prod ECR
+      id: push-prod
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.ecr-prod.outputs.registry }}
+      run: |
+        URI="$REGISTRY/${{ inputs.image-name }}:${{ inputs.image-tag }}"
+        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        docker push "$URI"
+        echo "uri=$URI" >> "$GITHUB_OUTPUT"
+
+    - if: contains(fromJSON(inputs.push-targets), 'prod')
+      name: Update Fargate service (Prod)
+      shell: bash
+      run: |
+        aws ecs update-service \
+          --cluster "${{ inputs.cluster-name }}" \
+          --service "${{ inputs.service-name }}" \
+          --force-new-deployment \
+          --no-cli-pager \
+          > /dev/null
+
+    # ----- GovCloud -----
+    - if: contains(fromJSON(inputs.push-targets), 'govcloud')
+      name: Configure AWS credentials (GovCloud)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-${{ steps.cfg.outputs.role-name }}
+        aws-region: us-gov-east-1
+
+    - if: contains(fromJSON(inputs.push-targets), 'govcloud')
+      name: Login to GovCloud ECR
+      id: ecr-govcloud
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - if: contains(fromJSON(inputs.push-targets), 'govcloud')
+      name: Push to GovCloud ECR
+      id: push-govcloud
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.ecr-govcloud.outputs.registry }}
+      run: |
+        URI="$REGISTRY/${{ inputs.image-name }}:${{ inputs.image-tag }}"
+        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        docker push "$URI"
+        echo "uri=$URI" >> "$GITHUB_OUTPUT"
+
+    - if: contains(fromJSON(inputs.push-targets), 'govcloud')
+      name: Update Fargate service (GovCloud)
+      shell: bash
+      run: |
+        aws ecs update-service \
+          --cluster "${{ inputs.cluster-name }}" \
+          --service "${{ inputs.service-name }}" \
+          --force-new-deployment \
+          --no-cli-pager \
+          > /dev/null

--- a/fargate-deploy-ecr/action.yaml
+++ b/fargate-deploy-ecr/action.yaml
@@ -21,11 +21,11 @@ inputs:
     description: 'IAM role suffix; defaults to the repo name. Full role: GitHub-<role-name>.'
     default: ''
   service-name:
-    description: 'ECS service name (required when push-targets is non-empty)'
-    required: true
+    description: 'ECS service name. Required when push-targets is non-empty; ignored otherwise.'
+    default: ''
   cluster-name:
-    description: 'ECS cluster name (required when push-targets is non-empty)'
-    required: true
+    description: 'ECS cluster name. Required when push-targets is non-empty; ignored otherwise.'
+    default: ''
 
 outputs:
   image-uri-prod:
@@ -38,21 +38,38 @@ outputs:
 runs:
   using: composite
   steps:
+    # All shell steps reference inputs via env vars rather than ${{ }} template
+    # interpolation, per GitHub's security hardening guide:
+    # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+    - name: Validate inputs
+      if: fromJSON(inputs.push-targets)[0] != null && (inputs.service-name == '' || inputs.cluster-name == '')
+      shell: bash
+      run: |
+        echo "::error::service-name and cluster-name are required when push-targets is non-empty"
+        exit 1
+
     - name: Resolve role name
       id: cfg
       shell: bash
+      env:
+        ROLE_NAME_INPUT: ${{ inputs.role-name }}
       run: |
-        NAME='${{ inputs.role-name }}'
+        NAME="$ROLE_NAME_INPUT"
         [ -z "$NAME" ] && NAME=${GITHUB_REPOSITORY#*/}
         echo "role-name=$NAME" >> "$GITHUB_OUTPUT"
 
     - name: Build Docker image
       shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
+        DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
+        DOCKER_CONTEXT_PATH: ${{ inputs.docker-context-path }}
       run: |
         docker buildx build --load \
-          -t "${{ inputs.image-name }}:${{ inputs.image-tag }}" \
-          -f "${{ inputs.dockerfile-path }}" \
-          "${{ inputs.docker-context-path }}"
+          -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+          -f "$DOCKERFILE_PATH" \
+          "$DOCKER_CONTEXT_PATH"
 
     # ----- Prod -----
     - if: contains(fromJSON(inputs.push-targets), 'prod')
@@ -73,22 +90,29 @@ runs:
       shell: bash
       env:
         REGISTRY: ${{ steps.ecr-prod.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
       run: |
-        URI="$REGISTRY/${{ inputs.image-name }}:${{ inputs.image-tag }}"
-        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        URI="$REGISTRY/${IMAGE_NAME}:${IMAGE_TAG}"
+        docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "$URI"
         docker push "$URI"
         echo "uri=$URI" >> "$GITHUB_OUTPUT"
 
     - if: contains(fromJSON(inputs.push-targets), 'prod')
       name: Update Fargate service (Prod)
       shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
+        SERVICE_NAME: ${{ inputs.service-name }}
       run: |
         aws ecs update-service \
-          --cluster "${{ inputs.cluster-name }}" \
-          --service "${{ inputs.service-name }}" \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME" \
           --force-new-deployment \
-          --no-cli-pager \
-          > /dev/null
+          --no-cli-pager
+        aws ecs wait services-stable \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME"
 
     # ----- GovCloud -----
     - if: contains(fromJSON(inputs.push-targets), 'govcloud')
@@ -109,19 +133,26 @@ runs:
       shell: bash
       env:
         REGISTRY: ${{ steps.ecr-govcloud.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
       run: |
-        URI="$REGISTRY/${{ inputs.image-name }}:${{ inputs.image-tag }}"
-        docker tag "${{ inputs.image-name }}:${{ inputs.image-tag }}" "$URI"
+        URI="$REGISTRY/${IMAGE_NAME}:${IMAGE_TAG}"
+        docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "$URI"
         docker push "$URI"
         echo "uri=$URI" >> "$GITHUB_OUTPUT"
 
     - if: contains(fromJSON(inputs.push-targets), 'govcloud')
       name: Update Fargate service (GovCloud)
       shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
+        SERVICE_NAME: ${{ inputs.service-name }}
       run: |
         aws ecs update-service \
-          --cluster "${{ inputs.cluster-name }}" \
-          --service "${{ inputs.service-name }}" \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME" \
           --force-new-deployment \
-          --no-cli-pager \
-          > /dev/null
+          --no-cli-pager
+        aws ecs wait services-stable \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME"


### PR DESCRIPTION
Superseded for the unified `deploy-ecr` work by #8.

This older PR branch contains the previous split-action approach (`build-and-push-ecr` and `fargate-deploy-ecr`) plus later branch history. Do not use it as the short branch reference for consumer workflow migrations.

Use:

```yaml
uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
```

Tracking PR: #8