### PR TITLE
Add unified deploy-ecr composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 # gh-actions
+
+Reusable GitHub Actions and composite actions for quiltdata repos.
+
+## Actions
+
+### [deploy-ecr](./deploy-ecr)
+
+Unified ECR image action. Builds a Docker image from the caller's checked-out
+workspace, pushes it to a configurable subset of ECR targets, and optionally
+forces ECS Fargate deployments for deployable targets.
+
+Targets:
+
+- `prod` - account 730278974607, us-east-1
+- `mp` - Marketplace account 709825985650, us-east-1, push-only
+- `govcloud` - account 313325871032, us-gov-east-1
+
+`push_targets: '[]'` builds only. Empty `image_tag` resolves to
+`git rev-parse HEAD`, which keeps image tags correct when a dispatch workflow
+checks out a different branch than the dispatching ref.
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    ref: ${{ inputs.ref || github.ref }}
+- uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
+  with:
+    image_name: quiltdata/catalog
+    push_targets: ${{ inputs.push_targets || '["prod","mp","govcloud"]' }}
+    mp_image_name: quilt-data/quilt-payg-catalog
+    role_name: Quilt
+```
+
+For ECS services, pass `cluster_name` and `service_name`; deployments run for
+pushed `prod` and `govcloud` targets only.
+
+```yaml
+- uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
+  with:
+    image_name: quiltdata/services/foo
+    cluster_name: my-cluster
+    service_name: my-service
+    push_targets: ${{ inputs.push_targets || '["prod","govcloud"]' }}
+```
+
+For Lambda-style image fanout, set `multi_region: 'true'` to push to every
+enabled region in each selected target account.
+
+## Conventions
+
+- All ECR-pushing actions assume the consumer repo has an IAM role at
+  `arn:aws:iam::<account>:role/github/GitHub-<role_name>` (and the GovCloud
+  equivalent), where `<role_name>` defaults to the repo name and can be
+  overridden via the `role_name` input.
+- The `push_targets` JSON-array pattern - default `["prod","govcloud"]` for
+  push events, `["prod"]` or `[]` for `workflow_dispatch` - lets
+  `workflow_dispatch` produce dev images without pushing to release-channel
+  registries.
+- Callers are responsible for `actions/checkout` before calling `deploy-ecr`
+  so setup and pre-build steps can populate the workspace first.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ pushed `prod` and `govcloud` targets only.
 For Lambda-style image fanout, set `multi_region: 'true'` to push to every
 enabled region in each selected target account.
 
+Use `additional_tags` when a workflow must preserve extra tags such as
+`latest`:
+
+```yaml
+    additional_tags: '["latest"]'
+```
+
+Use `docker_platform` and `build_args` when a workflow already pins build
+architecture or embeds build metadata:
+
+```yaml
+    docker_platform: linux/amd64
+    build_args: |
+      VERSION=${{ steps.git.outputs.sha }}
+```
+
 ## Conventions
 
 - All ECR-pushing actions assume the consumer repo has an IAM role at

--- a/deploy-ecr/action.yaml
+++ b/deploy-ecr/action.yaml
@@ -10,12 +10,21 @@ inputs:
   docker_context_path:
     description: 'Docker build context.'
     default: '.'
+  docker_platform:
+    description: 'Optional docker buildx platform, e.g. linux/amd64.'
+    default: ''
+  build_args:
+    description: 'Optional newline-delimited Docker build args, e.g. VERSION=abc123.'
+    default: ''
   image_name:
     description: 'ECR repository path, e.g. quiltdata/catalog or quiltdata/services/foo.'
     required: true
   image_tag:
     description: 'Image tag. Empty resolves to git rev-parse HEAD after caller checkout.'
     default: ''
+  additional_tags:
+    description: 'JSON array of additional tags to push for the same image, e.g. ["latest"].'
+    default: '[]'
   mp_image_name:
     description: 'Override image_name for the mp target, e.g. quilt-data/quilt-payg-catalog.'
     default: ''
@@ -95,11 +104,20 @@ runs:
         IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
         DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
         DOCKER_CONTEXT_PATH: ${{ inputs.docker_context_path }}
+        DOCKER_PLATFORM: ${{ inputs.docker_platform }}
+        BUILD_ARGS: ${{ inputs.build_args }}
       run: |
-        docker buildx build --load \
-          -t "${IMAGE_NAME}:${IMAGE_TAG}" \
-          -f "$DOCKERFILE_PATH" \
-          "$DOCKER_CONTEXT_PATH"
+        cmd=(docker buildx build --load)
+        if [ -n "$DOCKER_PLATFORM" ]; then
+          cmd+=(--platform "$DOCKER_PLATFORM")
+        fi
+        while IFS= read -r build_arg; do
+          if [ -n "$build_arg" ]; then
+            cmd+=(--build-arg "$build_arg")
+          fi
+        done <<< "$BUILD_ARGS"
+        cmd+=(-t "${IMAGE_NAME}:${IMAGE_TAG}" -f "$DOCKERFILE_PATH" "$DOCKER_CONTEXT_PATH")
+        "${cmd[@]}"
 
     # ----- Prod / Marketplace path (both authenticate via the Prod IAM role) -----
     - if: contains(fromJSON(inputs.push_targets), 'prod') || contains(fromJSON(inputs.push_targets), 'mp')
@@ -123,6 +141,7 @@ runs:
         REGISTRY: ${{ steps.ecr_prod.outputs.registry }}
         IMAGE_NAME: ${{ inputs.image_name }}
         IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
         MULTI_REGION: ${{ inputs.multi_region }}
       run: ${{ github.action_path }}/push_target.sh
 
@@ -160,6 +179,7 @@ runs:
         IMAGE_NAME: ${{ inputs.mp_image_name || inputs.image_name }}
         SOURCE_IMAGE: ${{ inputs.image_name }}:${{ steps.resolve_tag.outputs.value }}
         IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
         MULTI_REGION: 'false'
       run: ${{ github.action_path }}/push_target.sh
 
@@ -185,6 +205,7 @@ runs:
         REGISTRY: ${{ steps.ecr_govcloud.outputs.registry }}
         IMAGE_NAME: ${{ inputs.image_name }}
         IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
         MULTI_REGION: ${{ inputs.multi_region }}
       run: ${{ github.action_path }}/push_target.sh
 

--- a/deploy-ecr/action.yaml
+++ b/deploy-ecr/action.yaml
@@ -1,0 +1,205 @@
+---
+# yamllint disable rule:line-length
+name: 'Deploy ECR image'
+description: 'Build a Docker image, push to selected ECR targets, and optionally force ECS service deployments.'
+
+inputs:
+  dockerfile_path:
+    description: 'Path to the Dockerfile, relative to the workflow workspace.'
+    default: 'Dockerfile'
+  docker_context_path:
+    description: 'Docker build context.'
+    default: '.'
+  image_name:
+    description: 'ECR repository path, e.g. quiltdata/catalog or quiltdata/services/foo.'
+    required: true
+  image_tag:
+    description: 'Image tag. Empty resolves to git rev-parse HEAD after caller checkout.'
+    default: ''
+  mp_image_name:
+    description: 'Override image_name for the mp target, e.g. quilt-data/quilt-payg-catalog.'
+    default: ''
+  push_targets:
+    description: 'JSON array, subset of ["prod","mp","govcloud"]. [] = build only.'
+    default: '["prod","govcloud"]'
+  multi_region:
+    description: 'If true, push to every enabled region in each target account.'
+    default: 'false'
+  role_name:
+    description: 'IAM role suffix; defaults to the caller repo name. Full role: GitHub-<role_name>.'
+    default: ''
+  cluster_name:
+    description: 'ECS cluster. If set with service_name, deploys to pushed prod/govcloud targets. mp is push-only.'
+    default: ''
+  service_name:
+    description: 'ECS service. If set with cluster_name, deploys to pushed prod/govcloud targets. mp is push-only.'
+    default: ''
+
+outputs:
+  image_tag:
+    description: 'The tag actually used.'
+    value: ${{ steps.resolve_tag.outputs.value }}
+  image_uri_prod:
+    description: 'Full image URI in Prod ECR, empty if prod was not pushed.'
+    value: ${{ steps.push_prod.outputs.uri }}
+  image_uri_mp:
+    description: 'Full image URI in Marketplace ECR, empty if mp was not pushed.'
+    value: ${{ steps.push_mp.outputs.uri }}
+  image_uri_govcloud:
+    description: 'Full image URI in GovCloud ECR, empty if govcloud was not pushed.'
+    value: ${{ steps.push_govcloud.outputs.uri }}
+
+runs:
+  using: composite
+  steps:
+    # All shell steps reference inputs via env vars rather than direct
+    # expression interpolation, per GitHub's security hardening guide.
+    - name: Warn if ECS inputs have no deployable target
+      if: inputs.cluster_name != '' || inputs.service_name != ''
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster_name }}
+        SERVICE_NAME: ${{ inputs.service_name }}
+        PUSH_TARGETS: ${{ inputs.push_targets }}
+      run: |
+        if [ -z "$CLUSTER_NAME" ] || [ -z "$SERVICE_NAME" ]; then
+          echo "::warning::Both cluster_name and service_name are required for ECS deployment; ECS update will be skipped."
+        elif ! echo "$PUSH_TARGETS" | grep -qE '"(prod|govcloud)"'; then
+          echo "::warning::cluster_name/service_name were set, but push_targets contains no deployable target (prod or govcloud); ECS update will be skipped."
+        fi
+
+    - name: Resolve image tag
+      id: resolve_tag
+      shell: bash
+      env:
+        TAG_INPUT: ${{ inputs.image_tag }}
+      run: |
+        TAG="$TAG_INPUT"
+        [ -z "$TAG" ] && TAG="$(git rev-parse HEAD)"
+        echo "value=$TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve role name
+      id: cfg
+      shell: bash
+      env:
+        ROLE_NAME_INPUT: ${{ inputs.role_name }}
+      run: |
+        NAME="$ROLE_NAME_INPUT"
+        [ -z "$NAME" ] && NAME="${GITHUB_REPOSITORY#*/}"
+        echo "role_name=$NAME" >> "$GITHUB_OUTPUT"
+
+    - name: Build Docker image
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+        DOCKER_CONTEXT_PATH: ${{ inputs.docker_context_path }}
+      run: |
+        docker buildx build --load \
+          -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+          -f "$DOCKERFILE_PATH" \
+          "$DOCKER_CONTEXT_PATH"
+
+    # ----- Prod / Marketplace path (both authenticate via the Prod IAM role) -----
+    - if: contains(fromJSON(inputs.push_targets), 'prod') || contains(fromJSON(inputs.push_targets), 'mp')
+      name: Configure AWS credentials (Prod)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-${{ steps.cfg.outputs.role_name }}
+        aws-region: us-east-1
+
+    - if: contains(fromJSON(inputs.push_targets), 'prod')
+      name: Login to Prod ECR
+      id: ecr_prod
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - if: contains(fromJSON(inputs.push_targets), 'prod')
+      name: Push to Prod ECR
+      id: push_prod
+      shell: bash
+      env:
+        TARGET: prod
+        REGISTRY: ${{ steps.ecr_prod.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image_name }}
+        IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        MULTI_REGION: ${{ inputs.multi_region }}
+      run: ${{ github.action_path }}/push_target.sh
+
+    - if: contains(fromJSON(inputs.push_targets), 'prod') && inputs.cluster_name != '' && inputs.service_name != ''
+      name: Update Fargate service (Prod)
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster_name }}
+        SERVICE_NAME: ${{ inputs.service_name }}
+      run: |
+        aws ecs update-service \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME" \
+          --force-new-deployment \
+          --no-cli-pager
+        aws ecs wait services-stable \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME"
+
+    # ----- Marketplace is a distribution registry, not a deploy target. -----
+    - if: contains(fromJSON(inputs.push_targets), 'mp')
+      name: Login to Marketplace ECR
+      id: ecr_mp
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registries: '709825985650'
+
+    - if: contains(fromJSON(inputs.push_targets), 'mp')
+      name: Push to Marketplace ECR
+      id: push_mp
+      shell: bash
+      env:
+        TARGET: mp
+        REGISTRY: ${{ steps.ecr_mp.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.mp_image_name || inputs.image_name }}
+        SOURCE_IMAGE: ${{ inputs.image_name }}:${{ steps.resolve_tag.outputs.value }}
+        IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        MULTI_REGION: 'false'
+      run: ${{ github.action_path }}/push_target.sh
+
+    # ----- GovCloud path -----
+    - if: contains(fromJSON(inputs.push_targets), 'govcloud')
+      name: Configure AWS credentials (GovCloud)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-${{ steps.cfg.outputs.role_name }}
+        aws-region: us-gov-east-1
+
+    - if: contains(fromJSON(inputs.push_targets), 'govcloud')
+      name: Login to GovCloud ECR
+      id: ecr_govcloud
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - if: contains(fromJSON(inputs.push_targets), 'govcloud')
+      name: Push to GovCloud ECR
+      id: push_govcloud
+      shell: bash
+      env:
+        TARGET: govcloud
+        REGISTRY: ${{ steps.ecr_govcloud.outputs.registry }}
+        IMAGE_NAME: ${{ inputs.image_name }}
+        IMAGE_TAG: ${{ steps.resolve_tag.outputs.value }}
+        MULTI_REGION: ${{ inputs.multi_region }}
+      run: ${{ github.action_path }}/push_target.sh
+
+    - if: contains(fromJSON(inputs.push_targets), 'govcloud') && inputs.cluster_name != '' && inputs.service_name != ''
+      name: Update Fargate service (GovCloud)
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster_name }}
+        SERVICE_NAME: ${{ inputs.service_name }}
+      run: |
+        aws ecs update-service \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME" \
+          --force-new-deployment \
+          --no-cli-pager
+        aws ecs wait services-stable \
+          --cluster "$CLUSTER_NAME" \
+          --service "$SERVICE_NAME"

--- a/deploy-ecr/push_target.sh
+++ b/deploy-ecr/push_target.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${REGISTRY:?REGISTRY is required}"
+: "${IMAGE_NAME:?IMAGE_NAME is required}"
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+
+ACCOUNT_ID="${REGISTRY%%.*}"
+SOURCE="${SOURCE_IMAGE:-$IMAGE_NAME:$IMAGE_TAG}"
+MULTI_REGION="${MULTI_REGION:-false}"
+
+push_to_region() {
+  local region="$1"
+  local docker_url="$ACCOUNT_ID.dkr.ecr.$region.amazonaws.com"
+  local remote="$docker_url/$IMAGE_NAME:$IMAGE_TAG"
+
+  echo "Logging in to $docker_url..."
+  aws ecr get-login-password --region "$region" |
+    docker login -u AWS --password-stdin "$docker_url"
+
+  echo "Pushing $SOURCE to $remote..."
+  docker tag "$SOURCE" "$remote"
+  docker push "$remote"
+  echo "uri=$remote" >> "$GITHUB_OUTPUT"
+}
+
+if [ "$MULTI_REGION" = "true" ]; then
+  regions="$(aws ec2 describe-regions --query 'Regions[].RegionName' --output text)"
+  for region in $regions; do
+    push_to_region "$region"
+  done
+else
+  region="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+  if [ -z "$region" ]; then
+    echo "::error::AWS_REGION or AWS_DEFAULT_REGION is required for single-region push"
+    exit 1
+  fi
+  push_to_region "$region"
+fi

--- a/deploy-ecr/push_target.sh
+++ b/deploy-ecr/push_target.sh
@@ -9,6 +9,23 @@ set -euo pipefail
 ACCOUNT_ID="${REGISTRY%%.*}"
 SOURCE="${SOURCE_IMAGE:-$IMAGE_NAME:$IMAGE_TAG}"
 MULTI_REGION="${MULTI_REGION:-false}"
+ADDITIONAL_TAGS="${ADDITIONAL_TAGS:-[]}"
+
+additional_tags() {
+  node -e '
+    const input = process.env.ADDITIONAL_TAGS || "[]";
+    const tags = JSON.parse(input);
+    if (!Array.isArray(tags)) {
+      throw new Error("ADDITIONAL_TAGS must be a JSON array");
+    }
+    for (const tag of tags) {
+      if (typeof tag !== "string" || tag.length === 0) {
+        throw new Error("ADDITIONAL_TAGS entries must be non-empty strings");
+      }
+      console.log(tag);
+    }
+  '
+}
 
 push_to_region() {
   local region="$1"
@@ -23,6 +40,18 @@ push_to_region() {
   docker tag "$SOURCE" "$remote"
   docker push "$remote"
   echo "uri=$remote" >> "$GITHUB_OUTPUT"
+
+  local tags
+  tags="$(additional_tags)"
+  while IFS= read -r tag; do
+    if [ -z "$tag" ]; then
+      continue
+    fi
+    local additional_remote="$docker_url/$IMAGE_NAME:$tag"
+    echo "Pushing $SOURCE to $additional_remote..."
+    docker tag "$SOURCE" "$additional_remote"
+    docker push "$additional_remote"
+  done <<< "$tags"
 }
 
 if [ "$MULTI_REGION" = "true" ]; then


### PR DESCRIPTION
## Summary

Adds a single `deploy-ecr` composite action for Docker build, ECR push, optional multi-region fanout, and optional ECS service deployment.

This branch is intentionally short-lived and short-named so caller workflows can reference:

```yaml
uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
```

The action:

- builds from the caller's already-checked-out workspace
- resolves an empty `image_tag` to `git rev-parse HEAD`, so cross-branch dispatch images are tagged with the checked-out code SHA
- pushes to selected `push_targets`: `prod`, `mp`, and/or `govcloud`
- keeps Marketplace push-only with `mp_image_name` support
- optionally updates and waits for ECS services on deployable `prod` and `govcloud` targets when `cluster_name` and `service_name` are set
- supports `multi_region: 'true'` for Lambda-style image fanout
- supports `additional_tags`, `docker_platform`, and `build_args` so existing workflows that push `latest`, pin architecture, or pass build metadata can migrate without losing behavior

## Scope

This PR contains only the unified `deploy-ecr` action and README docs. It does not add or modify the older split `build-and-push-ecr` / `fargate-deploy-ecr` actions.

## Validation

- `yamllint deploy-ecr/action.yaml`
- `ruby -e 'require "yaml"; YAML.load_file("deploy-ecr/action.yaml"); puts "ok"'`
- `bash -n deploy-ecr/push_target.sh`
- `git diff --check HEAD~1..HEAD`

`actionlint` and `shellcheck` were not installed in the local environment.