### PR TITLE
lambda-deploy-ecr: add tag-prefix input + fix role-name typo

### DIFF
--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -25,7 +25,7 @@ runs:
     - uses: actions/checkout@v4
     - shell: bash
       name: Build Docker image
-      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}" -f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context-path }}
+      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
     - shell: bash
       name: Compute role name suffix
       id: role-name

--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -30,9 +30,9 @@ runs:
       name: Compute role name suffix
       id: role-name
       run: |
-        NAME=${{ inputs.role-name }}
-        REPO=${GITHUB_REPOSITORY#*/}
-        echo "role-name=$(echo ${NAME:-$REPO})" >> $GITHUB_OUTPUT
+        NAME="${{ inputs.role-name }}"
+        REPO="${GITHUB_REPOSITORY#*/}"
+        echo "role-name=${NAME:-$REPO}" >> "$GITHUB_OUTPUT"
     - name: Configure AWS credentials from Prod account
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -16,18 +16,21 @@ inputs:
   role-name:
     description: 'Name suffix of the role to assume (defaults to the repo name)'
     default: ''
+  tag-prefix:
+    description: 'Prepended to the image tag (e.g. "dev-" tags as "dev-<sha>"). Empty means tag is just <sha>.'
+    default: ''
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
     - shell: bash
       name: Build Docker image
-      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ github.sha }}" -f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context-path }}
+      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}" -f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context-path }}
     - shell: bash
       name: Compute role name suffix
       id: role-name
       run: |
-        NAME=${{ inputs.role_name }}
+        NAME=${{ inputs.role-name }}
         REPO=${GITHUB_REPOSITORY#*/}
         echo "role-name=$(echo ${NAME:-$REPO})" >> $GITHUB_OUTPUT
     - name: Configure AWS credentials from Prod account
@@ -37,7 +40,7 @@ runs:
         aws-region: us-east-1
     - shell: bash
       name: Push Docker image to Prod ECR
-      run: ${{ github.action_path }}/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ inputs.name }}:${{ github.sha }}"
+      run: ${{ github.action_path }}/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -47,4 +50,4 @@ runs:
     - if: ${{ inputs.govcloud  == 'true' }}
       shell: bash
       name: Push Docker image to GovCloud ECR
-      run: ${{ github.action_path }}/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ inputs.name }}:${{ github.sha }}"
+      run: ${{ github.action_path }}/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}"

--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -17,7 +17,7 @@ inputs:
     description: 'Name suffix of the role to assume (defaults to the repo name)'
     default: ''
   tag-prefix:
-    description: 'Prepended to the image tag (e.g. "dev-" tags as "dev-<sha>"). Empty means tag is just <sha>.'
+    description: 'Prepended to the SHA-based tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
     default: ''
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary

Two small changes to `lambda-deploy-ecr`:

1. **Add `tag-prefix` input.** Lets callers publish dev images as `dev-<sha>` (or any other prefix) by prepending to the image tag. Default is empty — every existing consumer behaves identically without change.
2. **Fix the `role-name` typo.** The input is declared `role-name` (dash) but the compute step reads `${{ inputs.role_name }}` (underscore), so the override silently never resolves and always falls through to the `${REPO}` default. No current quiltdata caller passes `role-name`, so this hasn't bit anyone yet — fixing while in the file.

## Why

The tabulator team needs a dispatchable variant of `docker-build-push.yaml` to publish dev images tagged `dev-<sha>` for feature-stack testing. Studying this action surfaced that it already encapsulates all the conventions we'd otherwise duplicate in a parallel workflow (multi-region fan-out, partition handling, the `GitHub-<repo-name>` IAM role convention). Adding `tag-prefix` here keeps the action as the single source of truth for "publish a lambda image" across all quiltdata lambdas, rather than forking the build/push surface per repo.

Downstream consumer (forthcoming): a thin reusable workflow on `quiltdata/tabulator` that wraps this action and exposes both:
- `workflow_call` (called from `test.yml` on master push) with `tag-prefix=''` → bare `<sha>` (current behavior)
- `workflow_dispatch` (for ad-hoc feature-stack builds) with `tag-prefix='dev-'` → `dev-<sha>`

Tracked as `qhq-3wuy.13` (upstream) and `qhq-3wuy.14` (downstream) in the QHQ workbench.

## Behavior

| Caller usage | Tag |
|---|---|
| `tag-prefix:` omitted | `<sha>` (existing) |
| `tag-prefix: ''` | `<sha>` (existing) |
| `tag-prefix: 'dev-'` | `dev-<sha>` |

Tag-prefix is applied uniformly to the docker build tag and both `upload_ecr.sh` calls (prod + govcloud), so multi-region fan-out and the govcloud branch behave identically — they just push under the prefixed tag.

## Test plan

- [x] Existing callers' behavior is preserved by the empty default — verified by inspection of the diff (the `tag-prefix` interpolation expands to empty string when omitted, yielding the prior `${{ inputs.name }}:${{ github.sha }}` tag exactly).
- [x] Verify the `role-name` typo fix doesn't break any caller — none today pass `role-name`, so the change is moot for current consumers. The shell expression `NAME=${{ inputs.role-name }}` is functionally identical to the previous `NAME=${{ inputs.role_name }}` for callers not passing it (both yield empty `NAME`, both fall through to `${REPO}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two targeted changes to `lambda-deploy-ecr/action.yaml`: it adds an optional `tag-prefix` input (empty by default, preserving existing behavior) that is applied uniformly to the docker build tag and both ECR push invocations, and it fixes a long-standing `role-name` / `role_name` underscore-vs-dash typo in the compute step that previously caused the input to silently resolve to nothing.

- **`tag-prefix` input**: threaded consistently through the `-t` flag and both `upload_ecr.sh` calls; multi-region fan-out and the GovCloud branch behave symmetrically.
- **`role-name` typo fix**: corrects `inputs.role_name` → `inputs.role-name` and upgrades surrounding shell quoting (`NAME`, `REPO`, and the `GITHUB_OUTPUT` redirect are now all double-quoted, with the gratuitous inner `echo` removed).
- **Docker build path quoting**: `-f` and the context-path argument are now double-quoted, addressing the previously raised Copilot finding. The only remaining quoting gap is `${{ github.action_path }}` on the two `upload_ecr.sh` invocation lines, which is a minor style inconsistency rather than a practical risk.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are narrow, backward-compatible, and the quoting improvements reduce rather than introduce risk.

The `tag-prefix` input defaults to empty so all existing callers are unaffected. The `role-name` typo fix is correct and provably moot for current callers. The docker build path-argument quoting (the previously flagged Copilot finding) is now addressed. The two remaining unquoted `${{ github.action_path }}` tokens are a style inconsistency on GitHub-controlled values that won't cause failures on any real runner.

No files require special attention; the two suggestion comments on lines 43 and 53 are optional polish.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambda-deploy-ecr/action.yaml | Adds `tag-prefix` input (applied uniformly across docker build and both ECR pushes), fixes `role-name` typo, and improves shell quoting in the role-name compute step and docker build paths. One minor residual quoting gap on the `upload_ecr.sh` invocation lines. |

</details>

<sub>Reviews (3): Last reviewed commit: ["lambda-deploy-ecr: quote docker buildx p..."](https://github.com/quiltdata/gh-actions/commit/f6e8c62ff722b8b44ce03a6fc14f119ae9fd35f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32822285)</sub>

<!-- /greptile_comment -->