### PR TITLE
actions: add version-prefix + regions inputs for lambda dev workflows

### DIFF
--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -16,8 +16,8 @@ inputs:
   role-name:
     description: 'Name suffix of the role to assume (defaults to the repo name)'
     default: ''
-  tag-prefix:
-    description: 'Prepended to the SHA-based tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
+  version-prefix:
+    description: 'Prepended to the SHA-based image tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
     default: ''
 runs:
   using: "composite"
@@ -25,7 +25,7 @@ runs:
     - uses: actions/checkout@v4
     - shell: bash
       name: Build Docker image
-      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
+      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
     - shell: bash
       name: Compute role name suffix
       id: role-name
@@ -40,7 +40,7 @@ runs:
         aws-region: us-east-1
     - shell: bash
       name: Push Docker image to Prod ECR
-      run: ${{ github.action_path }}/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}"
+      run: ${{ github.action_path }}/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -50,4 +50,4 @@ runs:
     - if: ${{ inputs.govcloud  == 'true' }}
       shell: bash
       name: Push Docker image to GovCloud ECR
-      run: ${{ github.action_path }}/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}"
+      run: ${{ github.action_path }}/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}"

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -54,7 +54,10 @@ runs:
         aws-region: us-east-1
     - shell: bash
       name: Upload zip to prod S3
-      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "${{ inputs.name }}" "${{ github.sha }}" us-east-1 "${{ inputs.tag-prefix }}"
+      env:
+        LAMBDA_NAME: ${{ inputs.name }}
+        TAG_PREFIX: ${{ inputs.tag-prefix }}
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "${{ github.sha }}" us-east-1 "$TAG_PREFIX"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -64,4 +67,7 @@ runs:
     - if: ${{ inputs.govcloud  == 'true' }}
       shell: bash
       name: Upload zip to GovCloud S3
-      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "${{ inputs.name }}" "${{ github.sha }}" us-gov-east-1 "${{ inputs.tag-prefix }}"
+      env:
+        LAMBDA_NAME: ${{ inputs.name }}
+        TAG_PREFIX: ${{ inputs.tag-prefix }}
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "${{ github.sha }}" us-gov-east-1 "$TAG_PREFIX"

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -13,8 +13,8 @@ inputs:
   role-name:
     description: 'Name suffix of the role to assume (defaults to the repo name)'
     default: ''
-  tag-prefix:
-    description: 'Prepended to the SHA-based S3 key (e.g. "dev-" yields "dev-<sha>.zip"). Empty means key is just <sha>.zip. Restricted to [A-Za-z0-9._-]* to keep the prefix in the filename segment.'
+  version-prefix:
+    description: 'Prepended to the SHA in the S3 key (e.g. "dev-" yields "<name>/dev-<sha>.zip"). Empty means key is just <name>/<sha>.zip. Restricted to [A-Za-z0-9._-]* to keep the prefix in the filename segment.'
     default: ''
   regions:
     description: 'Comma-separated list of regions to upload to. The first is the primary upload target; the rest are copies. Empty (default) means every region in the credentials'' partition — the prior behavior. Useful for dev workflows that only need the artifact in one or a few regions.'
@@ -59,10 +59,10 @@ runs:
       name: Upload zip to prod S3
       env:
         LAMBDA_NAME: ${{ inputs.name }}
-        TAG_PREFIX: ${{ inputs.tag-prefix }}
+        VERSION_PREFIX: ${{ inputs.version-prefix }}
         SHA: ${{ github.sha }}
         REGIONS: ${{ inputs.regions }}
-      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-east-1 "$TAG_PREFIX" "$REGIONS"
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-east-1 "$VERSION_PREFIX" "$REGIONS"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -74,7 +74,7 @@ runs:
       name: Upload zip to GovCloud S3
       env:
         LAMBDA_NAME: ${{ inputs.name }}
-        TAG_PREFIX: ${{ inputs.tag-prefix }}
+        VERSION_PREFIX: ${{ inputs.version-prefix }}
         SHA: ${{ github.sha }}
         REGIONS: ${{ inputs.regions }}
-      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-gov-east-1 "$TAG_PREFIX" "$REGIONS"
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-gov-east-1 "$VERSION_PREFIX" "$REGIONS"

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -14,7 +14,7 @@ inputs:
     description: 'Name suffix of the role to assume (defaults to the repo name)'
     default: ''
   tag-prefix:
-    description: 'Prepended to the SHA-based S3 key (e.g. "dev-" yields "dev-<sha>.zip"). Empty means key is just <sha>.zip.'
+    description: 'Prepended to the SHA-based S3 key (e.g. "dev-" yields "dev-<sha>.zip"). Empty means key is just <sha>.zip. Restricted to [A-Za-z0-9._-]* to keep the prefix in the filename segment.'
     default: ''
 runs:
   using: "composite"
@@ -57,7 +57,8 @@ runs:
       env:
         LAMBDA_NAME: ${{ inputs.name }}
         TAG_PREFIX: ${{ inputs.tag-prefix }}
-      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "${{ github.sha }}" us-east-1 "$TAG_PREFIX"
+        SHA: ${{ github.sha }}
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-east-1 "$TAG_PREFIX"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -70,4 +71,5 @@ runs:
       env:
         LAMBDA_NAME: ${{ inputs.name }}
         TAG_PREFIX: ${{ inputs.tag-prefix }}
-      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "${{ github.sha }}" us-gov-east-1 "$TAG_PREFIX"
+        SHA: ${{ github.sha }}
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-gov-east-1 "$TAG_PREFIX"

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -17,11 +17,23 @@ inputs:
     description: 'Prepended to the SHA in the S3 key (e.g. "dev-" yields "<name>/dev-<sha>.zip"). Empty means key is just <name>/<sha>.zip. Restricted to [A-Za-z0-9._-]* to keep the prefix in the filename segment.'
     default: ''
   regions:
-    description: 'Comma-separated list of regions to upload to. The first is the primary upload target; the rest are copies. Empty (default) means every region in the credentials'' partition — the prior behavior. Useful for dev workflows that only need the artifact in one or a few regions.'
+    description: 'Comma-separated list of regions to upload to. The first is the primary upload target; the rest are copies. Empty (default) means every region in the credentials'' partition — the prior behavior. Single-partition only; pair with `govcloud: false` (commercial/govcloud regions are disjoint and one list can''t serve both partitions).'
     default: ''
 runs:
   using: "composite"
   steps:
+    - if: ${{ inputs.regions != '' && inputs.govcloud == 'true' }}
+      shell: bash
+      name: Reject incompatible inputs (regions + govcloud)
+      # `regions` is single-partition by design — commercial and govcloud
+      # region pools are disjoint. With govcloud=true the same REGIONS env
+      # flows into both upload steps, so any commercial region triggers an
+      # auth failure on the govcloud step (and vice-versa). Fail fast with
+      # a clear message before AWS sees the misuse.
+      run: |
+        echo "::error::Setting 'regions' with 'govcloud: true' (default) is not supported. Set 'govcloud: false' alongside 'regions'." >&2
+        exit 1
+
     - shell: bash
       name: Zip directory
       id: zip

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -16,6 +16,9 @@ inputs:
   tag-prefix:
     description: 'Prepended to the SHA-based S3 key (e.g. "dev-" yields "dev-<sha>.zip"). Empty means key is just <sha>.zip. Restricted to [A-Za-z0-9._-]* to keep the prefix in the filename segment.'
     default: ''
+  regions:
+    description: 'Comma-separated list of regions to upload to. The first is the primary upload target; the rest are copies. Empty (default) means every region in the credentials'' partition — the prior behavior. Useful for dev workflows that only need the artifact in one or a few regions.'
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -58,7 +61,8 @@ runs:
         LAMBDA_NAME: ${{ inputs.name }}
         TAG_PREFIX: ${{ inputs.tag-prefix }}
         SHA: ${{ github.sha }}
-      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-east-1 "$TAG_PREFIX"
+        REGIONS: ${{ inputs.regions }}
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-east-1 "$TAG_PREFIX" "$REGIONS"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -72,4 +76,5 @@ runs:
         LAMBDA_NAME: ${{ inputs.name }}
         TAG_PREFIX: ${{ inputs.tag-prefix }}
         SHA: ${{ github.sha }}
-      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-gov-east-1 "$TAG_PREFIX"
+        REGIONS: ${{ inputs.regions }}
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "$LAMBDA_NAME" "$SHA" us-gov-east-1 "$TAG_PREFIX" "$REGIONS"

--- a/lambda-upload-s3/action.yaml
+++ b/lambda-upload-s3/action.yaml
@@ -13,6 +13,9 @@ inputs:
   role-name:
     description: 'Name suffix of the role to assume (defaults to the repo name)'
     default: ''
+  tag-prefix:
+    description: 'Prepended to the SHA-based S3 key (e.g. "dev-" yields "dev-<sha>.zip"). Empty means key is just <sha>.zip.'
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -51,7 +54,7 @@ runs:
         aws-region: us-east-1
     - shell: bash
       name: Upload zip to prod S3
-      run: ${{ github.action_path }}/upload_s3.sh ${{ steps.zip.outputs.zip-path }} ${{ inputs.name }} ${{ github.sha }} us-east-1
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "${{ inputs.name }}" "${{ github.sha }}" us-east-1 "${{ inputs.tag-prefix }}"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -61,4 +64,4 @@ runs:
     - if: ${{ inputs.govcloud  == 'true' }}
       shell: bash
       name: Upload zip to GovCloud S3
-      run: ${{ github.action_path }}/upload_s3.sh ${{ steps.zip.outputs.zip-path }} ${{ inputs.name }} ${{ github.sha }} us-gov-east-1
+      run: ${{ github.action_path }}/upload_s3.sh "${{ steps.zip.outputs.zip-path }}" "${{ inputs.name }}" "${{ github.sha }}" us-gov-east-1 "${{ inputs.tag-prefix }}"

--- a/lambda-upload-s3/upload_s3.sh
+++ b/lambda-upload-s3/upload_s3.sh
@@ -15,6 +15,15 @@ hash=$3
 primary_region=$4
 tag_prefix=${5:-}
 
+# Restrict tag_prefix to a safe character set so it stays within the
+# filename segment of the S3 key. Without this, a value containing `/`
+# (or `..`) would change the effective key path, e.g. tag_prefix=`dev/`
+# would land the artifact at `<name>/dev/<sha>.zip` instead of inside
+# the lambda's own prefix. Empty default is allowed.
+if [[ -n "$tag_prefix" && ! "$tag_prefix" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    error "tag_prefix must match [A-Za-z0-9._-]+ (got: '$tag_prefix')"
+fi
+
 s3_key="$lambda_name/${tag_prefix}${hash}.zip"
 
 regions=$(aws ec2 describe-regions --query "Regions[].{Name:RegionName}" --output text)

--- a/lambda-upload-s3/upload_s3.sh
+++ b/lambda-upload-s3/upload_s3.sh
@@ -7,14 +7,15 @@ error() {
     exit 1
 }
 
-[[ $# == 4 ]] || error "Usage: $0 zip_file lambda_name hash region"
+[[ $# == 5 ]] || error "Usage: $0 zip_file lambda_name hash region tag_prefix"
 
 zip_file=$1
 lambda_name=$2
 hash=$3
 primary_region=$4
+tag_prefix=$5
 
-s3_key="$lambda_name/$hash.zip"
+s3_key="$lambda_name/${tag_prefix}${hash}.zip"
 
 regions=$(aws ec2 describe-regions --query "Regions[].{Name:RegionName}" --output text)
 

--- a/lambda-upload-s3/upload_s3.sh
+++ b/lambda-upload-s3/upload_s3.sh
@@ -16,12 +16,11 @@ primary_region=$4
 tag_prefix=${5:-}
 
 # Restrict tag_prefix to a safe character set so it stays within the
-# filename segment of the S3 key. Without this, a value containing `/`
-# (or `..`) would change the effective key path, e.g. tag_prefix=`dev/`
-# would land the artifact at `<name>/dev/<sha>.zip` instead of inside
-# the lambda's own prefix. Empty default is allowed.
-if [[ -n "$tag_prefix" && ! "$tag_prefix" =~ ^[A-Za-z0-9._-]+$ ]]; then
-    error "tag_prefix must match [A-Za-z0-9._-]+ (got: '$tag_prefix')"
+# filename segment of the S3 key — e.g. `/` would change the effective
+# key path, landing artifacts at `<name>/dev/<sha>.zip` instead of
+# `<name>/dev-<sha>.zip`. `*` (vs `+`) lets the empty default pass.
+if [[ ! "$tag_prefix" =~ ^[A-Za-z0-9._-]*$ ]]; then
+    error "tag_prefix must match [A-Za-z0-9._-]* (got: '$tag_prefix')"
 fi
 
 s3_key="$lambda_name/${tag_prefix}${hash}.zip"

--- a/lambda-upload-s3/upload_s3.sh
+++ b/lambda-upload-s3/upload_s3.sh
@@ -7,21 +7,21 @@ error() {
     exit 1
 }
 
-[[ $# -ge 4 && $# -le 6 ]] || error "Usage: $0 zip_file lambda_name hash default_region [tag_prefix [regions_csv]]"
+[[ $# -ge 4 && $# -le 6 ]] || error "Usage: $0 zip_file lambda_name hash default_region [version_prefix [regions_csv]]"
 
 zip_file=$1
 lambda_name=$2
 hash=$3
 default_region=$4
-tag_prefix=${5:-}
+version_prefix=${5:-}
 regions_csv=${6:-}
 
-# Restrict tag_prefix to a safe character set so it stays within the
+# Restrict version_prefix to a safe character set so it stays within the
 # filename segment of the S3 key — e.g. `/` would change the effective
 # key path, landing artifacts at `<name>/dev/<sha>.zip` instead of
 # `<name>/dev-<sha>.zip`. `*` (vs `+`) lets the empty default pass.
-if [[ ! "$tag_prefix" =~ ^[A-Za-z0-9._-]*$ ]]; then
-    error "tag_prefix must match [A-Za-z0-9._-]* (got: '$tag_prefix')"
+if [[ ! "$version_prefix" =~ ^[A-Za-z0-9._-]*$ ]]; then
+    error "version_prefix must match [A-Za-z0-9._-]* (got: '$version_prefix')"
 fi
 
 # Resolve the region set: explicit comma-separated list, or every region
@@ -37,7 +37,7 @@ else
     regions=( $(aws ec2 describe-regions --query "Regions[].{Name:RegionName}" --output text) )
 fi
 
-s3_key="$lambda_name/${tag_prefix}${hash}.zip"
+s3_key="$lambda_name/${version_prefix}${hash}.zip"
 
 echo "Uploading to $primary_region..."
 aws s3 cp --acl public-read "$zip_file" --region "$primary_region" "s3://quilt-lambda-$primary_region/$s3_key"

--- a/lambda-upload-s3/upload_s3.sh
+++ b/lambda-upload-s3/upload_s3.sh
@@ -33,7 +33,6 @@ if [[ -n "$regions_csv" ]]; then
     primary_region="${regions[0]}"
 else
     primary_region=$default_region
-    # shellcheck disable=SC2207
     regions=( $(aws ec2 describe-regions --query "Regions[].{Name:RegionName}" --output text) )
 fi
 

--- a/lambda-upload-s3/upload_s3.sh
+++ b/lambda-upload-s3/upload_s3.sh
@@ -7,13 +7,14 @@ error() {
     exit 1
 }
 
-[[ $# == 4 || $# == 5 ]] || error "Usage: $0 zip_file lambda_name hash region [tag_prefix]"
+[[ $# -ge 4 && $# -le 6 ]] || error "Usage: $0 zip_file lambda_name hash default_region [tag_prefix [regions_csv]]"
 
 zip_file=$1
 lambda_name=$2
 hash=$3
-primary_region=$4
+default_region=$4
 tag_prefix=${5:-}
+regions_csv=${6:-}
 
 # Restrict tag_prefix to a safe character set so it stays within the
 # filename segment of the S3 key — e.g. `/` would change the effective
@@ -23,14 +24,25 @@ if [[ ! "$tag_prefix" =~ ^[A-Za-z0-9._-]*$ ]]; then
     error "tag_prefix must match [A-Za-z0-9._-]* (got: '$tag_prefix')"
 fi
 
-s3_key="$lambda_name/${tag_prefix}${hash}.zip"
+# Resolve the region set: explicit comma-separated list, or every region
+# in the credentials' partition (the prior behavior). When the caller
+# specifies regions, the first is the primary upload target; otherwise
+# we fall back to default_region as primary.
+if [[ -n "$regions_csv" ]]; then
+    IFS=',' read -ra regions <<< "$regions_csv"
+    primary_region="${regions[0]}"
+else
+    primary_region=$default_region
+    # shellcheck disable=SC2207
+    regions=( $(aws ec2 describe-regions --query "Regions[].{Name:RegionName}" --output text) )
+fi
 
-regions=$(aws ec2 describe-regions --query "Regions[].{Name:RegionName}" --output text)
+s3_key="$lambda_name/${tag_prefix}${hash}.zip"
 
 echo "Uploading to $primary_region..."
 aws s3 cp --acl public-read "$zip_file" --region "$primary_region" "s3://quilt-lambda-$primary_region/$s3_key"
 
-for region in $regions
+for region in "${regions[@]}"
 do
     if [[ $region != $primary_region ]]
     then

--- a/lambda-upload-s3/upload_s3.sh
+++ b/lambda-upload-s3/upload_s3.sh
@@ -7,13 +7,13 @@ error() {
     exit 1
 }
 
-[[ $# == 5 ]] || error "Usage: $0 zip_file lambda_name hash region tag_prefix"
+[[ $# == 4 || $# == 5 ]] || error "Usage: $0 zip_file lambda_name hash region [tag_prefix]"
 
 zip_file=$1
 lambda_name=$2
 hash=$3
 primary_region=$4
-tag_prefix=$5
+tag_prefix=${5:-}
 
 s3_key="$lambda_name/${tag_prefix}${hash}.zip"
 


### PR DESCRIPTION
## Summary

Two paired changes to make dev workflows for both code-publishing lambda actions ergonomic:

- **`version-prefix` input on both `lambda-deploy-ecr` and `lambda-upload-s3`** — prepended to the SHA in the published artifact's version identifier (image tag for ECR, S3 key filename for S3), so dev builds publish as `dev-<sha>` alongside prod `<sha>`. Renames the `tag-prefix` input that landed for ECR in #9 (`tag` was ECR-specific and misleading for S3; hard rename, no current consumers).
- **`regions` input on `lambda-upload-s3`** — opt-in selective fan-out. Empty default = current all-regions behavior. Useful for dev workflows that only need the artifact in one or a few regions instead of ~18.

## Why these together

A dev workflow for a lambda needs both knobs to be usable:

- Without `version-prefix`, dev and prod versions collide on the same key/tag.
- Without `regions`, every dev push (for S3 lambdas) fans out to ~18 commercial regions even when only one is consumed.

## `version-prefix`

Consistent across both actions:

| Caller | ECR image tag | S3 key |
|---|---|---|
| `version-prefix: ''` (default) | `<name>:<sha>` (unchanged) | `<name>/<sha>.zip` (unchanged) |
| `version-prefix: 'dev-'` | `<name>:dev-<sha>` | `<name>/dev-<sha>.zip` |

### Why a single `version-` term across both actions

`tag` is ECR-specific. For S3 the analogous prefix lands in the **filename**, not on a literal tag. Forcing the same `tag-prefix` name on the S3 action encoded a falsehood (sir-sigurd flagged this on #11). `version-prefix` reads consistently for both, matches the deployment-side terminology (the deployment pin is just `versions['lambda_name']`), and stays neutral about the underlying publishing mechanism.

### Why filename-segment placement (S3)

Grounded in the deployment-side consumer at `quiltdata/deployment/t4/template/helpers.py:185-189`:

```python
def get_s3_lambda_code_zip(lambda_name: str, env):
    return awslambda.Code(
        S3Bucket=Sub("quilt-lambda-${AWS::Region}"),
        S3Key=f"{lambda_name}/{env['versions'][lambda_name]}.zip",
    )
```

To deploy a dev variant, the deployment-side env sets `versions['name'] = 'dev-<sha>'` and the same formula produces `<name>/dev-<sha>.zip`. **Zero deployment-side changes**. The alternative `dev/<name>/<sha>.zip` layout would require either changing `get_s3_lambda_code_zip` or making callers construct fully-qualified S3Keys themselves.

### Charset (S3)

`version-prefix` is restricted to `[A-Za-z0-9._-]*` so the prefix stays in the filename segment — `/` would change the effective key path. Documented in the input description.

### Lifecycle bookkeeping caveat (S3)

With this layout, dev artifacts can't be expired by a single bucket-wide `Prefix: dev/` rule — each lambda needs its own `Prefix: <name>/dev-` rule. **Followup tracked: lifecycle policies in `infra-templates` (or manual setup if the buckets aren't templated).** Sergey's object-tagging suggestion (`--tagging "env=dev"` + single tag-based rule) is the cleaner long-term answer; that needs `s3:PutObjectTagging` on the deployer roles and is a separate change.

## `regions` (S3 only)

Comma-separated. First region in the list is the primary upload target; the rest are S3 copies from primary. Empty default falls back to `aws ec2 describe-regions` over the partition — **current behavior preserved exactly**.

| Caller | Effective fan-out |
|---|---|
| `regions: ''` (default) | all regions in the partition (unchanged) |
| `regions: 'us-east-2'` | primary upload to us-east-2 only; no copies |
| `regions: 'us-east-1,us-west-2,eu-central-1'` | primary us-east-1, copies to us-west-2 + eu-central-1 |

`upload_s3.sh` now takes 4-6 positional args (vs 4-5 before): the 6th is the regions CSV. Direct CLI invocations omitting it continue to work unchanged.

## Hardening (sir-sigurd's #11 round-2)

The original PR added quoting around `${{ inputs.* }}` interpolations but didn't close the GHA-template-injection surface — GHA substitutes `${{ }}` expressions into the script source *before* bash parses, so `$(...)` in a value executes despite quotes (same class #10 caught for the zip + role-name steps).

Closed via env-var pass-through on both upload steps (`LAMBDA_NAME`, `VERSION_PREFIX`, `SHA`, `REGIONS`). Now every caller-input and GHA-provided interpolation in this action's `run:` blocks goes through env, mirroring PR #10's pattern.

Also addresses sir-sigurd's smaller findings on #11:
- Drop the misleading `..` claim from the script comment (S3 keys are flat strings; `..` never traversed paths)
- Simplify the charset guard (regex `+` → `*` absorbs the empty default; the redundant `-n "$version_prefix"` pre-check is gone)
- Document the charset in the input description

## Followups (filed as beads)

- Lifecycle policies on `quilt-lambda-<region>` buckets (probably in `infra-templates`, or manual setup if untemplated)
- Object-tagging in `upload_s3.sh` + `s3:PutObjectTagging` on deployer roles (sir-sigurd's #4 — enables single-rule lifecycle without changing layout)

## Downstream

`quiltdata/tabulator#130` (draft) is the only consumer wiring the ECR `version-prefix` input. Will update once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `version-prefix` to both `lambda-deploy-ecr` and `lambda-upload-s3` (hard-renaming ECR's `tag-prefix`) and adds a `regions` input to `lambda-upload-s3` for selective fan-out. The S3 upload steps are hardened against GHA template injection via env-var pass-through, and a fast-fail guard prevents the incompatible `regions` + `govcloud: true` combination.

- **`version-prefix`** (both actions): prepended to the SHA in the published artifact identifier; empty default preserves existing behavior exactly.
- **`regions`** (S3 only): comma-separated list for selective region fan-out; empty default falls back to `aws ec2 describe-regions` over the partition; a guard step exits 1 with a clear message when `regions` is non-empty and `govcloud == 'true'`.
- **Template-injection hardening** (S3 upload steps): `LAMBDA_NAME`, `VERSION_PREFIX`, `SHA`, and `REGIONS` now flow through `env:` blocks rather than being interpolated directly into `run:` shells.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the guard correctly blocks the incompatible regions+govcloud combination, env-var pass-through closes the injection surface for S3, and default behavior is fully preserved.

All three changed files make additive, backward-compatible changes. The previously-raised regions/govcloud conflict is properly resolved with a fast-fail guard. The only remaining nit is that spaces after commas in the regions CSV are not trimmed before being passed to the AWS CLI, which would only surface if a caller formats the input that way.

No files require special attention; upload_s3.sh has the minor CSV-whitespace sensitivity noted above.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambda-deploy-ecr/action.yaml | Hard-renames `tag-prefix` to `version-prefix`; the interpolation pattern is unchanged from before this PR. |
| lambda-upload-s3/action.yaml | Adds `version-prefix` and `regions` inputs; introduces a fast-fail guard for the incompatible `regions` + `govcloud: true` combination; applies env-var pass-through to both upload steps. |
| lambda-upload-s3/upload_s3.sh | Extends positional args to accept `version_prefix` and `regions_csv`; adds charset guard; resolves region set from CSV or `describe-regions`. Spaces after commas in the CSV are not stripped and would produce invalid region names. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[lambda-upload-s3 action called] --> B{regions != '' AND govcloud == 'true'?}
    B -->|Yes| C[❌ Fail fast: incompatible inputs error]
    B -->|No| D[Zip directory]
    D --> E[Compute role name]
    E --> F[Configure Prod AWS credentials]
    F --> G[upload_s3.sh — Prod\nus-east-1 as default_region]
    G --> H{regions_csv non-empty?}
    H -->|Yes — explicit list| I[Use first region as primary\nCopy to remaining regions]
    H -->|No — all regions| J[aws ec2 describe-regions\nUpload + copy all]
    I --> K{govcloud == 'true'?}
    J --> K
    K -->|Yes| L[Configure GovCloud credentials]
    L --> M[upload_s3.sh — GovCloud\nus-gov-east-1 as default_region]
    M --> N[Same region resolution logic]
    K -->|No| O[Done]
    N --> O
```

<sub>Reviews (6): Last reviewed commit: ["lambda-upload-s3: reject regions + govcl..."](https://github.com/quiltdata/gh-actions/commit/e1e9fa1aeb172337f63e666a03c010610e7ce73c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32969726)</sub>

<!-- /greptile_comment -->