### PR TITLE
lambda-deploy-ecr: rename tag-prefix -> version-prefix

### DIFF
--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -16,8 +16,8 @@ inputs:
   role-name:
     description: 'Name suffix of the role to assume (defaults to the repo name)'
     default: ''
-  tag-prefix:
-    description: 'Prepended to the SHA-based tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
+  version-prefix:
+    description: 'Prepended to the SHA-based image tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
     default: ''
 runs:
   using: "composite"
@@ -25,7 +25,7 @@ runs:
     - uses: actions/checkout@v4
     - shell: bash
       name: Build Docker image
-      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
+      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
     - shell: bash
       name: Compute role name suffix
       id: role-name
@@ -40,7 +40,7 @@ runs:
         aws-region: us-east-1
     - shell: bash
       name: Push Docker image to Prod ECR
-      run: ${{ github.action_path }}/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}"
+      run: ${{ github.action_path }}/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -50,4 +50,4 @@ runs:
     - if: ${{ inputs.govcloud  == 'true' }}
       shell: bash
       name: Push Docker image to GovCloud ECR
-      run: ${{ github.action_path }}/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.tag-prefix }}${{ github.sha }}"
+      run: ${{ github.action_path }}/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}"


### PR DESCRIPTION
## Summary

Renames the input added in #9 from `tag-prefix` to `version-prefix`. Hard rename, no deprecated alias.

## Why

`tag` is ECR-specific terminology — it confuses when readers map the concept across to the parallel `lambda-upload-s3` action (#11), where the analogous prefix lands in the S3 *key filename*, not on a literal "tag." For both code-publishing actions the prefix conceptually disambiguates which **version** of the lambda is being published (prod `<sha>` vs dev `dev-<sha>`). That's what the deployment side actually consumes too — `env['versions'][lambda_name]` is just a string, with or without a prefix.

`version-prefix` reads consistently for both actions and aligns with the deployment-side terminology.

## Safety for current callers

The `tag-prefix` input landed in #9 a few hours ago and has no current consumer in `quiltdata/*`:

- `gh search code` org-wide returns no matches for `tag-prefix:` against `lambda-deploy-ecr@`
- `quiltdata/tabulator#130` is the only other place that references it, still in draft

Will update tabulator#130 to use `version-prefix` in the same merge window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renames the `tag-prefix` input to `version-prefix` in `lambda-deploy-ecr/action.yaml`, updating all four usage sites (the input declaration and three `run` commands). The change is mechanical and complete, with a small description improvement ("SHA-based image tag").

- All occurrences of `${{ inputs.tag-prefix }}` are replaced with `${{ inputs.version-prefix }}` — no leftover references.
- Hard rename with no deprecated alias, as documented in the PR description; the author confirms no current consumers in the org.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a rename with no logic changes, and all four reference sites are updated consistently.

The change is a complete, mechanical rename across one file. Every use of the old input name has been updated, the default value and behaviour are unchanged, and the PR description confirms there are no current consumers in the org.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambda-deploy-ecr/action.yaml | Renames the `tag-prefix` input to `version-prefix` in all four locations (declaration + three run commands); description also tightened to say "SHA-based image tag". Rename is complete and consistent. |

</details>

<sub>Reviews (1): Last reviewed commit: ["lambda-deploy-ecr: rename tag-prefix -&gt; ..."](https://github.com/quiltdata/gh-actions/commit/6e1769623ed569c2f530400b9d3a0322f81bf106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32992383)</sub>

<!-- /greptile_comment -->