### PR TITLE
lambda-deploy-ecr: add opt-in cache-scope input for GHA buildx cache

### DIFF
--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -30,21 +30,31 @@ runs:
     # sets up a docker-container buildx builder, wires the GHA cache runtime
     # token, and `load: true` puts the built image into the local docker store
     # so the subsequent `docker tag` + `docker push` steps work unchanged.
-    - if: inputs.cache-scope != ''
+    # `use: false` keeps the default docker driver as the active buildx
+    # builder, so a later invocation of this composite in the same job with
+    # an empty cache-scope still gets the bare-`docker buildx build` path
+    # below (which relies on the default driver to land the image in the
+    # local store).
+    - if: ${{ inputs.cache-scope != '' }}
+      id: cached-buildx
       uses: docker/setup-buildx-action@v3
-    - if: inputs.cache-scope != ''
+      with:
+        use: false
+    - if: ${{ inputs.cache-scope != '' }}
       name: Build Docker image (cached)
       uses: docker/build-push-action@v6
       with:
+        builder: ${{ steps.cached-buildx.outputs.name }}
         context: ${{ inputs.docker-context-path }}
         file: ${{ inputs.dockerfile-path }}
         tags: quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}
+        push: false
         load: true
         cache-from: type=gha,scope=${{ inputs.cache-scope }}
         cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
     # No-cache path: byte-identical to the prior behavior (default docker
     # driver, no cache import/export). Selected by an empty cache-scope.
-    - if: inputs.cache-scope == ''
+    - if: ${{ inputs.cache-scope == '' }}
       shell: bash
       name: Build Docker image
       run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"

--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -20,21 +20,26 @@ inputs:
     description: 'Prepended to the SHA-based image tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
     default: ''
   cache-scope:
-    description: 'Opt into GHA buildx layer cache for the docker build under this scope name. Empty default = no cache (preserves prior behavior). To share cache with sibling jobs in the consumer repo (e.g. a PR-time docker-build-check), set the same scope on both sides.'
+    description: 'Empty (default) = no cache, byte-identical prior behavior. Non-empty = opt into GHA buildx layer cache under this scope name; set the same scope in sibling jobs (e.g. a PR-time docker-build-check) to share layers across them. Scope should be a simple identifier — avoid `,` and `=`, which collide with the type=gha,scope=... config syntax.'
     default: ''
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    # Cached build path: opt-in via `cache-scope`. docker/build-push-action
-    # sets up a docker-container buildx builder, wires the GHA cache runtime
-    # token, and `load: true` puts the built image into the local docker store
-    # so the subsequent `docker tag` + `docker push` steps work unchanged.
-    # `use: false` keeps the default docker driver as the active buildx
-    # builder, so a later invocation of this composite in the same job with
-    # an empty cache-scope still gets the bare-`docker buildx build` path
-    # below (which relies on the default driver to land the image in the
-    # local store).
+    - shell: bash
+      name: Compute image tag
+      id: image-tag
+      env:
+        LAMBDA_NAME: ${{ inputs.name }}
+        VERSION_PREFIX: ${{ inputs.version-prefix }}
+        SHA: ${{ github.sha }}
+      run: echo "image-tag=quiltdata/lambdas/${LAMBDA_NAME}:${VERSION_PREFIX}${SHA}" >> "$GITHUB_OUTPUT"
+    # Cached build path: opt-in via `cache-scope`. `use: false` keeps the
+    # default docker driver as the active buildx builder so a later
+    # invocation of this composite in the same job with an empty cache-scope
+    # still resolves to the bare-buildx path below. `load: true` is required
+    # so the image lands in the local docker store for the per-region
+    # `docker tag` + `docker push` steps that run after AWS creds are set.
     - if: ${{ inputs.cache-scope != '' }}
       id: cached-buildx
       uses: docker/setup-buildx-action@v3
@@ -47,17 +52,17 @@ runs:
         builder: ${{ steps.cached-buildx.outputs.name }}
         context: ${{ inputs.docker-context-path }}
         file: ${{ inputs.dockerfile-path }}
-        tags: quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}
+        tags: ${{ steps.image-tag.outputs.image-tag }}
         push: false
         load: true
         cache-from: type=gha,scope=${{ inputs.cache-scope }}
         cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
-    # No-cache path: byte-identical to the prior behavior (default docker
-    # driver, no cache import/export). Selected by an empty cache-scope.
     - if: ${{ inputs.cache-scope == '' }}
       shell: bash
       name: Build Docker image
-      run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
+      env:
+        IMAGE_TAG: ${{ steps.image-tag.outputs.image-tag }}
+      run: docker buildx build -t "$IMAGE_TAG" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
     - shell: bash
       name: Compute role name suffix
       id: role-name
@@ -72,7 +77,9 @@ runs:
         aws-region: us-east-1
     - shell: bash
       name: Push Docker image to Prod ECR
-      run: ${{ github.action_path }}/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}"
+      env:
+        IMAGE_TAG: ${{ steps.image-tag.outputs.image-tag }}
+      run: ${{ github.action_path }}/upload_ecr.sh 730278974607 "$IMAGE_TAG"
     - if: ${{ inputs.govcloud  == 'true' }}
       name: Configure AWS credentials from GovCloud account
       uses: aws-actions/configure-aws-credentials@v4
@@ -82,4 +89,6 @@ runs:
     - if: ${{ inputs.govcloud  == 'true' }}
       shell: bash
       name: Push Docker image to GovCloud ECR
-      run: ${{ github.action_path }}/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}"
+      env:
+        IMAGE_TAG: ${{ steps.image-tag.outputs.image-tag }}
+      run: ${{ github.action_path }}/upload_ecr.sh 313325871032 "$IMAGE_TAG"

--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -19,11 +19,33 @@ inputs:
   version-prefix:
     description: 'Prepended to the SHA-based image tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
     default: ''
+  cache-scope:
+    description: 'Opt into GHA buildx layer cache for the docker build under this scope name. Empty default = no cache (preserves prior behavior). To share cache with sibling jobs in the consumer repo (e.g. a PR-time docker-build-check), set the same scope on both sides.'
+    default: ''
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - shell: bash
+    # Cached build path: opt-in via `cache-scope`. docker/build-push-action
+    # sets up a docker-container buildx builder, wires the GHA cache runtime
+    # token, and `load: true` puts the built image into the local docker store
+    # so the subsequent `docker tag` + `docker push` steps work unchanged.
+    - if: inputs.cache-scope != ''
+      uses: docker/setup-buildx-action@v3
+    - if: inputs.cache-scope != ''
+      name: Build Docker image (cached)
+      uses: docker/build-push-action@v6
+      with:
+        context: ${{ inputs.docker-context-path }}
+        file: ${{ inputs.dockerfile-path }}
+        tags: quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}
+        load: true
+        cache-from: type=gha,scope=${{ inputs.cache-scope }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
+    # No-cache path: byte-identical to the prior behavior (default docker
+    # driver, no cache import/export). Selected by an empty cache-scope.
+    - if: inputs.cache-scope == ''
+      shell: bash
       name: Build Docker image
       run: docker buildx build -t "quiltdata/lambdas/${{ inputs.name }}:${{ inputs.version-prefix }}${{ github.sha }}" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
     - shell: bash


### PR DESCRIPTION
## Summary

Adds an opt-in `cache-scope` input to `lambda-deploy-ecr` that routes the docker build through `docker/setup-buildx-action@v3` + `docker/build-push-action@v6` with `cache-from`/`cache-to: type=gha`. Empty default = no cache (byte-identical prior behavior); set it to opt in.

## Motivation

Consumer repos that adopt a PR-time `docker-build-check` (concretely: `quiltdata/tabulator#132`) can cache PR-side rebuilds via GHA buildx cache today. But the cache GitHub creates from a PR is scoped to that PR — `main`-side runs never warm it, so every new PR pays the full cold build (~18 min for tabulator).

Closing this cross-PR cold start needs the upstream action — which owns the `main`-side build — to also populate the GHA cache, using the same scope name as the consumer-side `docker-build-check`. With the same scope on both sides, `main` builds warm the cache that PRs read.

## Why expose the scope (not a boolean)

`type=gha` defaults the cache scope to the git ref, so a `main` build and a PR build would land in different scopes and not share. Cross-job sharing requires an explicit scope name. A `use-gha-cache: bool` input couldn't expose that — the consumer needs to pick a stable scope name (e.g. `tabulator-lambda`) and set it on both the PR-side build and the action call.

## Why this shape (not always-cache)

A boolean ceiling change (e.g. always `setup-buildx`, always `--load`) would switch every existing consumer from the default `docker` driver to the `docker-container` driver. Functionally equivalent for our flow but a subtle behavioral change. Keeping two paths (`if: inputs.cache-scope != ''`) means existing consumers see zero diff until they opt in.

The `load: true` on the cached path is required by the action's existing flow: `upload_ecr.sh` does `docker tag` + `docker push` per region after the build, which reads from the local docker image store. Without `--load`, the buildx-container build doesn't expose the image to the local daemon.

## Backward compatibility

- `cache-scope: ''` (default) → unchanged behavior, byte-identical bare `docker buildx build` step.
- `cache-scope: '<scope>'` → cached buildx-container build via `docker/build-push-action`, image loaded into local store, downstream tag+push steps unchanged.

No other inputs touched. No upload_ecr.sh change.

## Verification

This repo has no CI of its own (composite-actions repo). Plan:

- [ ] After merge, wire `cache-scope: tabulator-lambda` into the tabulator main-push wrapper (`docker-build-push.yml`) and the matching scope into `tabulator.yml`'s `docker-build-check`.
- [ ] First PR-after-main-merge should reuse the dep layer warmed by main (warm `docker-build-check`).
- [ ] Confirm main-push still publishes correctly to all regions (the load:true path produces a functional image).
- [ ] Confirm the no-cache path is unaffected for other consumers (verify a non-opting consumer's next deploy looks identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in `cache-scope` input to the `lambda-deploy-ecr` composite action, routing the Docker build through `docker/setup-buildx-action@v3` + `docker/build-push-action@v6` with GHA layer caching when a scope name is provided. An empty default leaves all existing consumers on the original bare `docker buildx build` path with no behavioral change.

- **Cached path**: when `cache-scope` is non-empty, a dedicated buildx builder is created with `use: false` (so the default driver is not replaced) and `build-push-action` explicitly targets it with `cache-from`/`cache-to: type=gha,scope=…` and `load: true` so the image lands in the local daemon for the downstream per-region tag+push steps.
- **Tag refactor**: the image tag is now computed once in a dedicated `Compute image tag` step and passed via `GITHUB_OUTPUT`, eliminating the repeated inline expression that was duplicated across the build and push steps.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two-path design ensures zero behavioral change for existing consumers and the cached path is correctly wired with `use: false`, `load: true`, and explicit `push: false`.

The opt-in design means any consumer that does not set `cache-scope` sees the identical bare `docker buildx build` step. The cached path correctly creates a dedicated builder without replacing the default driver, loads the image into the local daemon for the downstream push steps, and the tag refactor eliminates the previously duplicated inline expression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambda-deploy-ecr/action.yaml | Adds opt-in GHA buildx caching via a new `cache-scope` input; backward-compatible two-path design with correct `use: false`, `load: true`, explicit `push: false`, and single-source image tag computation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start] --> B[Checkout]
    B --> C[Compute image tag]
    C --> D{cache-scope set?}
    D -->|Yes| E[setup-buildx-action v3 use: false]
    E --> F[build-push-action v6 cache-from/cache-to: type=gha load: true, push: false]
    D -->|No| G[docker buildx build no cache]
    F --> H[Compute role name suffix]
    G --> H
    H --> I[Configure AWS creds - Prod]
    I --> J[upload_ecr.sh - Prod]
    J --> K{govcloud == true?}
    K -->|Yes| L[Configure AWS creds - GovCloud]
    L --> M[upload_ecr.sh - GovCloud]
    K -->|No| N[Done]
    M --> N
```

<sub>Reviews (2): Last reviewed commit: ["lambda-deploy-ecr: extract image tag to ..."](https://github.com/quiltdata/gh-actions/commit/1179167d5601deb4e68f71db00887b5c639860ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34371408)</sub>

<!-- /greptile_comment -->