### PR TITLE
lambda-deploy-ecr: opt-in ECR registry build cache

### DIFF
--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -68,6 +68,7 @@ runs:
       name: Log in to Prod ECR (for cache)
       uses: aws-actions/amazon-ecr-login@v2
     - if: ${{ inputs.registry-cache == 'true' }}
+      name: Set up buildx for registry-cache build
       id: registry-buildx
       uses: docker/setup-buildx-action@v3
       with:
@@ -82,8 +83,8 @@ runs:
         tags: ${{ steps.image-tag.outputs.image-tag }}
         push: false
         load: true
-        cache-from: type=registry,ref=${{ steps.cache-ref.outputs.ref }}
-        cache-to: type=registry,ref=${{ steps.cache-ref.outputs.ref }},mode=max,image-manifest=true,oci-mediatypes=true
+        cache-from: type=registry,ref=${{ steps.cache-ref.outputs.ref }},ignore-error=true
+        cache-to: type=registry,ref=${{ steps.cache-ref.outputs.ref }},mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
 
     # --- Bare build path (no cache) --------------------------------------------
     - if: ${{ inputs.registry-cache != 'true' }}

--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -19,11 +19,8 @@ inputs:
   version-prefix:
     description: 'Prepended to the SHA-based image tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
     default: ''
-  cache-scope:
-    description: 'Empty (default) = no cache, byte-identical prior behavior. Non-empty = opt into GHA buildx layer cache under this scope name; set the same scope in sibling jobs (e.g. a PR-time docker-build-check) to share layers across them. Scope should be a simple identifier — avoid `,` and `=`, which collide with the type=gha,scope=... config syntax. Ignored when `registry-cache` is enabled.'
-    default: ''
   registry-cache:
-    description: 'true = cache build layers in ECR (a `:buildcache` tag on this lambda''s Prod repo) instead of the GHA cache. Unlike the GHA cache, this is not subject to the 10 GB/repo budget, so the heavy dependency layer persists across runs; it is also shareable with a PR-time docker-build-check that reads the same ref. Requires the Prod role to have ECR pull/push on the repo (it already does, for the image push).'
+    description: 'true = cache build layers in ECR (a `:buildcache` tag on this lambda''s Prod repo). Not subject to the GHA 10 GB/repo cache budget, so the heavy dependency layer persists across runs; also shareable with a PR-time docker-build-check that reads the same ref. Requires the Prod role to have ECR pull/push on the repo (it already does, for the image push).'
     default: 'false'
 runs:
   using: "composite"
@@ -88,32 +85,8 @@ runs:
         cache-from: type=registry,ref=${{ steps.cache-ref.outputs.ref }}
         cache-to: type=registry,ref=${{ steps.cache-ref.outputs.ref }},mode=max,image-manifest=true,oci-mediatypes=true
 
-    # --- GHA-cache build path --------------------------------------------------
-    # Opt-in via `cache-scope`. `use: false` keeps the default docker driver as
-    # the active buildx builder so a later invocation of this composite in the
-    # same job with an empty cache-scope still resolves to the bare-buildx path
-    # below. `load: true` is required so the image lands in the local docker
-    # store for the per-region `docker tag` + `docker push` steps below.
-    - if: ${{ inputs.registry-cache != 'true' && inputs.cache-scope != '' }}
-      id: cached-buildx
-      uses: docker/setup-buildx-action@v3
-      with:
-        use: false
-    - if: ${{ inputs.registry-cache != 'true' && inputs.cache-scope != '' }}
-      name: Build Docker image (cached)
-      uses: docker/build-push-action@v6
-      with:
-        builder: ${{ steps.cached-buildx.outputs.name }}
-        context: ${{ inputs.docker-context-path }}
-        file: ${{ inputs.dockerfile-path }}
-        tags: ${{ steps.image-tag.outputs.image-tag }}
-        push: false
-        load: true
-        cache-from: type=gha,scope=${{ inputs.cache-scope }}
-        cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
-
-    # --- Bare build path -------------------------------------------------------
-    - if: ${{ inputs.registry-cache != 'true' && inputs.cache-scope == '' }}
+    # --- Bare build path (no cache) --------------------------------------------
+    - if: ${{ inputs.registry-cache != 'true' }}
       shell: bash
       name: Build Docker image
       env:

--- a/lambda-deploy-ecr/action.yaml
+++ b/lambda-deploy-ecr/action.yaml
@@ -20,8 +20,11 @@ inputs:
     description: 'Prepended to the SHA-based image tag (e.g. "dev-" yields "dev-<sha>"). Empty means tag is just <sha>.'
     default: ''
   cache-scope:
-    description: 'Empty (default) = no cache, byte-identical prior behavior. Non-empty = opt into GHA buildx layer cache under this scope name; set the same scope in sibling jobs (e.g. a PR-time docker-build-check) to share layers across them. Scope should be a simple identifier — avoid `,` and `=`, which collide with the type=gha,scope=... config syntax.'
+    description: 'Empty (default) = no cache, byte-identical prior behavior. Non-empty = opt into GHA buildx layer cache under this scope name; set the same scope in sibling jobs (e.g. a PR-time docker-build-check) to share layers across them. Scope should be a simple identifier — avoid `,` and `=`, which collide with the type=gha,scope=... config syntax. Ignored when `registry-cache` is enabled.'
     default: ''
+  registry-cache:
+    description: 'true = cache build layers in ECR (a `:buildcache` tag on this lambda''s Prod repo) instead of the GHA cache. Unlike the GHA cache, this is not subject to the 10 GB/repo budget, so the heavy dependency layer persists across runs; it is also shareable with a PR-time docker-build-check that reads the same ref. Requires the Prod role to have ECR pull/push on the repo (it already does, for the image push).'
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -34,18 +37,69 @@ runs:
         VERSION_PREFIX: ${{ inputs.version-prefix }}
         SHA: ${{ github.sha }}
       run: echo "image-tag=quiltdata/lambdas/${LAMBDA_NAME}:${VERSION_PREFIX}${SHA}" >> "$GITHUB_OUTPUT"
-    # Cached build path: opt-in via `cache-scope`. `use: false` keeps the
-    # default docker driver as the active buildx builder so a later
-    # invocation of this composite in the same job with an empty cache-scope
-    # still resolves to the bare-buildx path below. `load: true` is required
-    # so the image lands in the local docker store for the per-region
-    # `docker tag` + `docker push` steps that run after AWS creds are set.
-    - if: ${{ inputs.cache-scope != '' }}
+    # role-name and the Prod ECR cache ref are computed up front because the
+    # registry-cache build below needs Prod creds + an ECR login *before* the
+    # build (the cache is read/written during the build, not at push time).
+    - shell: bash
+      name: Compute role name suffix
+      id: role-name
+      run: |
+        NAME="${{ inputs.role-name }}"
+        REPO="${GITHUB_REPOSITORY#*/}"
+        echo "role-name=${NAME:-$REPO}" >> "$GITHUB_OUTPUT"
+    - if: ${{ inputs.registry-cache == 'true' }}
+      shell: bash
+      name: Compute registry cache ref
+      id: cache-ref
+      env:
+        LAMBDA_NAME: ${{ inputs.name }}
+      # A `:buildcache` tag on the same Prod ECR repo the image is pushed to —
+      # no separate repo to provision. us-east-1 matches the Prod creds region.
+      run: echo "ref=730278974607.dkr.ecr.us-east-1.amazonaws.com/quiltdata/lambdas/${LAMBDA_NAME}:buildcache" >> "$GITHUB_OUTPUT"
+
+    # --- Registry-cache build path (ECR) ---------------------------------------
+    # Needs Prod creds + ECR docker login before the build so buildx can pull
+    # and push the cache manifest. ECR requires the OCI / image-manifest cache
+    # format (it rejects buildkit's default cache manifest).
+    - if: ${{ inputs.registry-cache == 'true' }}
+      name: Configure AWS credentials for cache (Prod)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-${{ steps.role-name.outputs.role-name }}
+        aws-region: us-east-1
+    - if: ${{ inputs.registry-cache == 'true' }}
+      name: Log in to Prod ECR (for cache)
+      uses: aws-actions/amazon-ecr-login@v2
+    - if: ${{ inputs.registry-cache == 'true' }}
+      id: registry-buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        use: false
+    - if: ${{ inputs.registry-cache == 'true' }}
+      name: Build Docker image (registry cache)
+      uses: docker/build-push-action@v6
+      with:
+        builder: ${{ steps.registry-buildx.outputs.name }}
+        context: ${{ inputs.docker-context-path }}
+        file: ${{ inputs.dockerfile-path }}
+        tags: ${{ steps.image-tag.outputs.image-tag }}
+        push: false
+        load: true
+        cache-from: type=registry,ref=${{ steps.cache-ref.outputs.ref }}
+        cache-to: type=registry,ref=${{ steps.cache-ref.outputs.ref }},mode=max,image-manifest=true,oci-mediatypes=true
+
+    # --- GHA-cache build path --------------------------------------------------
+    # Opt-in via `cache-scope`. `use: false` keeps the default docker driver as
+    # the active buildx builder so a later invocation of this composite in the
+    # same job with an empty cache-scope still resolves to the bare-buildx path
+    # below. `load: true` is required so the image lands in the local docker
+    # store for the per-region `docker tag` + `docker push` steps below.
+    - if: ${{ inputs.registry-cache != 'true' && inputs.cache-scope != '' }}
       id: cached-buildx
       uses: docker/setup-buildx-action@v3
       with:
         use: false
-    - if: ${{ inputs.cache-scope != '' }}
+    - if: ${{ inputs.registry-cache != 'true' && inputs.cache-scope != '' }}
       name: Build Docker image (cached)
       uses: docker/build-push-action@v6
       with:
@@ -57,19 +111,15 @@ runs:
         load: true
         cache-from: type=gha,scope=${{ inputs.cache-scope }}
         cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
-    - if: ${{ inputs.cache-scope == '' }}
+
+    # --- Bare build path -------------------------------------------------------
+    - if: ${{ inputs.registry-cache != 'true' && inputs.cache-scope == '' }}
       shell: bash
       name: Build Docker image
       env:
         IMAGE_TAG: ${{ steps.image-tag.outputs.image-tag }}
       run: docker buildx build -t "$IMAGE_TAG" -f "${{ inputs.dockerfile-path }}" "${{ inputs.docker-context-path }}"
-    - shell: bash
-      name: Compute role name suffix
-      id: role-name
-      run: |
-        NAME="${{ inputs.role-name }}"
-        REPO="${GITHUB_REPOSITORY#*/}"
-        echo "role-name=${NAME:-$REPO}" >> "$GITHUB_OUTPUT"
+
     - name: Configure AWS credentials from Prod account
       uses: aws-actions/configure-aws-credentials@v4
       with:


### PR DESCRIPTION
## Why
The GHA buildx cache (`type=gha`) is capped at **10 GB/repo with LRU eviction**. For a heavy image like tabulator's lambda (datafusion/arrow/aws), the ~540 MiB dependency layer gets evicted between runs, so `cargo lambda build` recompiles it every time (~16 min PR check / ~22 min build & push). Raising the budget isn't possible; the layer needs to live outside it.

## What
Add an opt-in `registry-cache` input (default `false`). When `true`, build layers are cached to a **`:buildcache` tag on the lambda's Prod ECR repo** via buildx `type=registry`:
- No 10 GB budget → the dependency layer persists and is reused.
- Shareable: a PR-time `docker-build-check` can `cache-from` the same ECR ref.
- Uses the **Prod role the action already assumes** for the image push — no new IAM.

Also **drops the GHA `cache-scope` path entirely**: tabulator was its only consumer (confirmed via org-wide code search) and it's the thing we're escaping. The action is now a clean binary split — `registry-cache` (opt-in, ECR) vs the unchanged bare build (default, byte-identical to before).

Implementation notes:
- `role-name` + the cache ref are computed up front, and Prod creds + `amazon-ecr-login` run **before** the build (the cache is pulled/pushed *during* the build, not at push time).
- `cache-to` passes ECR's required `image-manifest=true,oci-mediatypes=true` (ECR rejects buildkit's default cache manifest format).

## Consumer
Wired in quiltdata/tabulator#135 (pins this branch until it merges, then re-pins `@main`).

## Validated (e2e on tabulator, `docker-build-push` dispatched twice on the same commit, govcloud=false)
- **Cold** (run 27013144166): `cache-from` miss (non-fatal), `cargo lambda build` dep layer built in **780 s**, `cache-to` wrote the `:buildcache` manifest to ECR (no errors), image pushed. ~26 min.
- **Warm** (run 27014628363): `cache-from` **hit** (OCI image-manifest round-trips through ECR cleanly), every build layer `CACHED`, **2 min 3 s** total.

## Reviewer notes
- The `:buildcache` tag lives on the same `quiltdata/lambdas/<name>` repo (no separate cache repo). Confirm that's acceptable, and that ECR lifecycle policies won't expire a tagged-but-not-deployed image.
- IAM (resolved for tabulator): PR consumers (`docker-build-check`) assume `GitHub-<name>` via OIDC to `cache-from`. The `GitHub-tabulator` role trust is `sub: repo:quiltdata/tabulator:*` — the `:*` wildcard admits `pull_request`, and its policy already grants ECR read+write on `quiltdata/lambdas/tabulator`. A repo whose `GitHub-<name>` trust is ref-restricted (e.g. only `refs/heads/main`) would need that loosened or a read-only role before enabling `registry-cache` on PR jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the GHA `cache-scope` input with an opt-in `registry-cache` input that stores Docker build layers as a `:buildcache` tag on the lambda's Prod ECR repo, bypassing the 10 GB GHA cache budget that was causing full rebuilds of the heavy Rust/datafusion dependency layer.

- Adds a new `registry-cache: 'true'` path that pre-authenticates with Prod ECR before the build, sets up an isolated buildx builder (`use: false`), and runs `docker/build-push-action@v6` with `type=registry` cache (ECR-required `image-manifest=true,oci-mediatypes=true`; `ignore-error=true` on both importer and exporter).
- Moves `Compute role name suffix` before the build steps so the Prod role ARN is available for the pre-build ECR login without duplicating logic.
- Removes `cache-scope` entirely (sole consumer confirmed via org-wide search migrating to `registry-cache` in the same changeset); the bare build path is byte-identical to the prior default.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped, e2e validated, and all prior review feedback has been addressed.

The step sequencing is correct: role-name is computed before it is referenced in the cache-creds ARN, ECR login runs before the build that needs cache access, and the isolated buildx builder (use: false) avoids interfering with the default builder used by the bare path. Both cache-from and cache-to carry ignore-error=true, making cold-miss and transient-push failures graceful. The govcloud credential swap happens after cache I/O is complete.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambda-deploy-ecr/action.yaml | Replaces GHA cache-scope with opt-in ECR registry-cache; sequencing, gating conditions, buildx isolation, and ECR format options all look correct; previous review feedback (ignore-error, name:, cache-scope removal) fully addressed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant ECR_Prod as Prod ECR (us-east-1)
    participant Docker as Docker Daemon
    participant ECR_Gov as GovCloud ECR

    GHA->>GHA: Compute image tag
    GHA->>GHA: Compute role name suffix

    alt "registry-cache == true"
        GHA->>GHA: Compute cache ref (:buildcache tag)
        GHA->>ECR_Prod: Configure AWS creds (Prod role)
        GHA->>ECR_Prod: ECR login (docker credentials stored)
        GHA->>GHA: Set up isolated buildx builder (use: false)
        GHA->>Docker: "Build image (type=registry cache-from ECR)"
        ECR_Prod-->>Docker: "Pull cache layers (ignore-error=true)"
        Docker->>ECR_Prod: "Push cache manifest (image-manifest=true, oci-mediatypes=true, ignore-error=true)"
        Docker->>GHA: Image loaded locally
    else "registry-cache != true"
        GHA->>Docker: docker buildx build (no cache)
        Docker->>GHA: Image loaded locally
    end

    GHA->>ECR_Prod: Configure AWS creds (Prod role)
    GHA->>ECR_Prod: upload_ecr.sh push image

    opt "govcloud == true"
        GHA->>ECR_Gov: Configure AWS creds (GovCloud role)
        GHA->>ECR_Gov: upload_ecr.sh push image
    end
```

<sub>Reviews (3): Last reviewed commit: ["lambda-deploy-ecr: name the registry-cac..."](https://github.com/quiltdata/gh-actions/commit/2d9ad04d6afccd0f4df2be296032f32f15af5b8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35828772)</sub>

<!-- /greptile_comment -->